### PR TITLE
feat: dogfood plugin rules in ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'eslint/config'
 import js from '@eslint/js'
+import laststancePlugin from './index.js'
 
 export default defineConfig([
   // Global ignores
@@ -13,6 +14,9 @@ export default defineConfig([
   // Main configuration for all JavaScript files
   {
     files: ['**/*.js'],
+    plugins: {
+      laststance: laststancePlugin,
+    },
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -34,6 +38,20 @@ export default defineConfig([
       // Consistency rules
       semi: ['warn', 'never'],
       quotes: ['warn', 'single', { avoidEscape: true }],
+
+      // Dogfooding: Use our own plugin rules to validate the plugin works
+      // While this codebase doesn't contain React components, enabling these
+      // rules serves as:
+      // - Living documentation of proper plugin configuration
+      // - Validation that the plugin works when applied to a project
+      // - Protection against accidental React code without proper patterns
+      'laststance/no-jsx-without-return': 'warn',
+      'laststance/all-memo': 'warn',
+      'laststance/no-use-reducer': 'warn',
+      'laststance/no-set-state-prop-drilling': 'warn',
+      'laststance/no-deopt-use-callback': 'warn',
+      'laststance/prefer-stable-context-value': 'warn',
+      'laststance/no-unstable-classname-prop': 'warn',
     },
   },
 ])


### PR DESCRIPTION
## Summary

Enables all plugin rules in the ESLint configuration to demonstrate proper usage and validate the plugin works when applied to itself ("dogfooding").

## Motivation

While this ESLint plugin provides rules for React/Next.js projects, and the plugin's own codebase doesn't contain React components, enabling the plugin's rules on itself provides significant value:

### 1. 📚 Living Documentation
Shows developers **exactly** how to configure the plugin in their own projects. This is better than just having examples in README.md because:
- The configuration is actively used and tested
- It's guaranteed to be up-to-date
- It demonstrates real-world usage

### 2. ✅ Self-Validation
Ensures the plugin functions correctly when imported and applied:
- Validates that all rules can be enabled without errors
- Catches plugin loading or registration issues
- Proves the plugin works in a real ESLint configuration

### 3. 🛡️ Future Protection
If React code is ever added to this codebase:
- Rules will catch potential issues automatically
- Maintains code quality standards
- Demonstrates the plugin's value

### 4. 🎓 Educational Value
Provides a reference implementation for:
- How to import the plugin
- How to add it to the plugins object
- How to configure rules
- Best practices for rule severity levels

## Changes

**Modified: `eslint.config.js`**

```diff
+ import laststancePlugin from './index.js'

  {
    files: ['**/*.js'],
+   plugins: {
+     laststance: laststancePlugin,
+   },
    rules: {
+     // Dogfooding: Use our own plugin rules
+     'laststance/no-jsx-without-return': 'warn',
+     'laststance/all-memo': 'warn',
+     'laststance/no-use-reducer': 'warn',
+     'laststance/no-set-state-prop-drilling': 'warn',
+     'laststance/no-deopt-use-callback': 'warn',
+     'laststance/prefer-stable-context-value': 'warn',
+     'laststance/no-unstable-classname-prop': 'warn',
    }
  }
```

**All Rules Enabled:**
- ✅ `no-jsx-without-return` - Catch missing return statements with JSX
- ✅ `all-memo` - Enforce React.memo usage
- ✅ `no-use-reducer` - Discourage useReducer in favor of Redux Toolkit
- ✅ `no-set-state-prop-drilling` - Prevent useState setter prop drilling
- ✅ `no-deopt-use-callback` - Flag meaningless useCallback usage
- ✅ `prefer-stable-context-value` - Enforce stable Context.Provider values
- ✅ `no-unstable-classname-prop` - Prevent unstable className expressions

All rules are set to **`'warn'`** level to provide guidance without being overly strict.

## Validation

- [x] `pnpm lint` runs successfully (no warnings - expected since no React code)
- [x] All 62 tests pass
- [x] Plugin imports and loads correctly
- [x] All rules register without errors
- [x] Configuration is clear and well-documented

## Technical Details

### Why This Works

The plugin can lint itself because:
1. ESLint flat config allows importing local modules
2. The plugin exports its rules correctly
3. Rules don't crash on non-React code (they simply don't trigger)

### Expected Behavior

Currently, no warnings are produced because:
- The codebase contains no actual React components
- Test files use JSX in string literals, not actual JSX code
- The rules appropriately ignore non-matching code

If React code is added in the future, the rules will:
- Provide helpful warnings about potential issues
- Enforce best practices automatically
- Maintain code quality standards

## Dependencies

This PR depends on PR #8 (adding eslint.config.js). It extends the base configuration with plugin dogfooding.

## Related Issues

Part of the comprehensive quality improvement initiative following the code analysis.

## Impact

✅ **Benefits:**
- Demonstrates proper plugin configuration
- Validates plugin functionality
- Provides living documentation
- Future-proofs the codebase

⚠️ **Considerations:**
- No immediate functional changes (no warnings expected)
- Minimal performance impact (rules only check matching patterns)
- Easy to adjust rule severity if needed

## How to Test

```bash
# Clone and install
git checkout feat/dogfood-plugin-rules
pnpm install

# Verify lint works
pnpm lint
# Expected: Clean output (no errors or warnings)

# Verify tests pass
pnpm test
# Expected: 62 passing tests

# Review configuration
cat eslint.config.js
# Expected: Plugin imported and all rules enabled
```

## Screenshots

**ESLint Config with Dogfooding:**
```javascript
import laststancePlugin from './index.js'

export default defineConfig([
  {
    plugins: {
      laststance: laststancePlugin,  // ← Plugin dogfooded
    },
    rules: {
      'laststance/no-jsx-without-return': 'warn',  // ← All rules enabled
      // ... (6 more rules)
    }
  }
])
```

## References

- ["Eating your own dog food"](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) - Wikipedia
- [ESLint Flat Config Plugins](https://eslint.org/docs/latest/use/configure/plugins) - Official ESLint Documentation