### PR TITLE
feat(rule): add no-jsx-iife with lint e2e coverage

### DIFF
--- a/.github/workflows/todo-e2e.yml
+++ b/.github/workflows/todo-e2e.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   todo-e2e:
-    name: Run todo app ESLint snapshot (Node ${{ matrix.node-version }}, ESLint v${{ matrix.eslint-major }})
+    name: Run todo app ESLint E2E (Node ${{ matrix.node-version }}, ESLint v${{ matrix.eslint-major }})
     runs-on: ubuntu-latest
 
     permissions:
@@ -63,5 +63,5 @@ jobs:
       - name: Switch ESLint major for matrix run
         run: pnpm --filter todo-lint-app add -D eslint@${{ steps.eslint-version.outputs.eslint }}
 
-      - name: Run todo app ESLint snapshot suite
+      - name: Run todo app ESLint E2E suite
         run: pnpm test:todo-e2e

--- a/README.md
+++ b/README.md
@@ -587,10 +587,13 @@ Move the computation outside JSX, then reference the resulting value in the temp
 **❌ Incorrect**
 
 ```jsx
+// Inline arrow IIFE inside JSX — obscures a trivial string constant.
 <div>{(() => 'x')()}</div>
 
+// IIFE wraps a plain call, adding an unnecessary closure per render.
 <Button label={(() => computeLabel())()} />
 
+// Function-expression IIFE inside JSX hides the computation that produced `statusText`.
 <section>{(function () {
   return formatStatus(status)
 })()}</section>
@@ -599,6 +602,7 @@ Move the computation outside JSX, then reference the resulting value in the temp
 **✅ Correct**
 
 ```jsx
+// Bind values to named variables outside JSX so the template stays declarative.
 const message = 'x'
 const label = computeLabel()
 const statusText = formatStatus(status)

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ export default [
       '@laststance/react-next/no-missing-key': 'error',
       '@laststance/react-next/no-duplicate-key': 'error',
       '@laststance/react-next/jsx-no-useless-fragment': 'error',
+      '@laststance/react-next/no-jsx-iife': 'error',
       '@laststance/react-next/no-missing-component-display-name': 'error',
       '@laststance/react-next/no-nested-component-definitions': 'error',
       '@laststance/react-next/no-missing-button-type': 'error',
       '@laststance/react-next/prefer-stable-context-value': 'error',
       '@laststance/react-next/prefer-usecallback-might-work': 'error',
-      '@laststance/react-next/prefer-usecallback-for-memoized-component': 'error',
+      '@laststance/react-next/prefer-usecallback-for-memoized-component':
+        'error',
       '@laststance/react-next/prefer-usememo-for-memoized-component': 'error',
       '@laststance/react-next/prefer-usememo-might-work': 'error',
     },
@@ -84,6 +86,7 @@ Some rules are imported and adapted from https://github.com/jsx-eslint/eslint-pl
 - [`laststance/no-missing-key`](docs/rules/no-missing-key.md): Disallow list items without `key`
 - [`laststance/no-duplicate-key`](docs/rules/no-duplicate-key.md): Disallow duplicate `key` values among siblings
 - [`laststance/jsx-no-useless-fragment`](docs/rules/jsx-no-useless-fragment.md): Disallow fragments that do not add structure
+- [`laststance/no-jsx-iife`](docs/rules/no-jsx-iife.md): Disallow immediately invoked function expressions inside JSX
 - [`laststance/no-missing-component-display-name`](docs/rules/no-missing-component-display-name.md): Require `displayName` for anonymous memo/forwardRef components
 - [`laststance/no-nested-component-definitions`](docs/rules/no-nested-component-definitions.md): Disallow defining components inside other components
 - [`laststance/no-missing-button-type`](docs/rules/no-missing-button-type.md): Require explicit `type` for button elements
@@ -547,19 +550,13 @@ This rule requires sibling elements to have unique `key` values.
 **❌ Incorrect**
 
 ```javascript
-return [
-  <Item key="a" />,
-  <Item key="a" />,
-]
+return [<Item key="a" />, <Item key="a" />]
 ```
 
 **✅ Correct**
 
 ```javascript
-return [
-  <Item key="a" />,
-  <Item key="b" />,
-]
+return [<Item key="a" />, <Item key="b" />]
 ```
 
 ### `jsx-no-useless-fragment`
@@ -580,6 +577,28 @@ This rule disallows fragments that do not add structure and can be removed safel
 <Foo />
 
 <p>text</p>
+```
+
+### `no-jsx-iife`
+
+This rule disallows immediately invoked function expressions inside JSX.
+
+**❌ Incorrect**
+
+```jsx
+<div>{(() => 'x')()}</div>
+
+<Button label={(() => computeLabel())()} />
+```
+
+**✅ Correct**
+
+```jsx
+const label = computeLabel()
+
+<div>{label}</div>
+
+<Button label={label} />
 ```
 
 ### `no-missing-component-display-name`

--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ This rule disallows fragments that do not add structure and can be removed safel
 ### `no-jsx-iife`
 
 This rule disallows immediately invoked function expressions inside JSX.
+Move the computation outside JSX, then reference the resulting value in the template instead.
 
 **❌ Incorrect**
 
@@ -589,17 +590,27 @@ This rule disallows immediately invoked function expressions inside JSX.
 <div>{(() => 'x')()}</div>
 
 <Button label={(() => computeLabel())()} />
+
+<section>{(function () {
+  return formatStatus(status)
+})()}</section>
 ```
 
 **✅ Correct**
 
 ```jsx
+const message = 'x'
 const label = computeLabel()
+const statusText = formatStatus(status)
 
-<div>{label}</div>
+<div>{message}</div>
 
 <Button label={label} />
+
+<section>{statusText}</section>
 ```
+
+This rule has no options.
 
 ### `no-missing-component-display-name`
 

--- a/apps/todo-lint-app/eslint.config.mjs
+++ b/apps/todo-lint-app/eslint.config.mjs
@@ -21,6 +21,7 @@ const eslintConfig = defineConfig([
       'laststance/no-missing-key': 'warn',
       'laststance/no-duplicate-key': 'warn',
       'laststance/jsx-no-useless-fragment': 'warn',
+      'laststance/no-jsx-iife': 'warn',
       'laststance/no-missing-component-display-name': 'warn',
       'laststance/no-nested-component-definitions': 'warn',
       'laststance/no-missing-button-type': 'warn',

--- a/apps/todo-lint-app/package.json
+++ b/apps/todo-lint-app/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "test:e2e": "vitest run tests/lint-snapshot.test.ts tests/lint-focused.test.ts",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/apps/todo-lint-app/src/app/invalid/page.tsx
+++ b/apps/todo-lint-app/src/app/invalid/page.tsx
@@ -10,6 +10,7 @@ const FORWARDED_BUTTON_LABEL = 'Forwarded'
 const MISSING_TYPE_LABEL = 'Missing type'
 const USELESS_FRAGMENT_SINGLE_CHILD_LABEL = 'Single child wrapped by fragment'
 const USELESS_FRAGMENT_HOST_LABEL = 'Host wrapper fragment'
+const JSX_IIFE_LABEL = 'JSX IIFE label'
 
 type ThemeValue = {
   theme: string
@@ -125,6 +126,9 @@ export default function InvalidPage() {
           </>
           <div className="rounded-md border border-cyan-300 bg-cyan-50 px-3 py-2 text-sm text-cyan-900">
             <>{USELESS_FRAGMENT_HOST_LABEL}</>
+          </div>
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            {(() => JSX_IIFE_LABEL)()}
           </div>
           <NestedBadge />
         </section>

--- a/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v10.snap
+++ b/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v10.snap
@@ -1,12 +1,12 @@
 
 <projectRoot>/tests/fixtures/eslint-v10/page.jsx
    6:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                                                                                      laststance/no-forward-ref
-   7:10  warning  Missing an explicit type attribute for button                                                                                                                                                       laststance/no-missing-button-type
-  11:3   warning  Component "V10CompatFixture" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                          laststance/no-direct-use-effect
-  14:5   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                               laststance/no-context-provider
-  14:28  warning  Avoid passing a new object literal to Context.Provider "value" on each render. Wrap it in useMemo/useCallback to provide a stable reference and prevent unnecessary context consumers re-rendering  laststance/prefer-stable-context-value
-  15:7   warning  Missing an explicit type attribute for button                                                                                                                                                       laststance/no-missing-button-type
-  18:9   warning  A fragment placed inside a host component is useless                                                                                                                                                laststance/jsx-no-useless-fragment
+  15:3   warning  Component "V10CompatFixture" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                          laststance/no-direct-use-effect
+  18:5   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                               laststance/no-context-provider
+  18:28  warning  Avoid passing a new object literal to Context.Provider "value" on each render. Wrap it in useMemo/useCallback to provide a stable reference and prevent unnecessary context consumers re-rendering  laststance/prefer-stable-context-value
+  19:7   warning  Missing an explicit type attribute for button                                                                                                                                                       laststance/no-missing-button-type
+  21:11  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                                                                 laststance/no-jsx-iife
+  23:9   warning  A fragment placed inside a host component is useless                                                                                                                                                laststance/jsx-no-useless-fragment
 
 ✖ 7 problems (0 errors, 7 warnings)
   0 errors and 2 warnings potentially fixable with the `--fix` option.

--- a/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
+++ b/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
@@ -1,12 +1,13 @@
 
 <projectRoot>/src/app/invalid/page.tsx
-   42:3   warning  Add missing 'displayName' for component                                                laststance/no-missing-component-display-name
-   51:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead         laststance/no-forward-ref
-   96:3   warning  Do not nest component definitions inside other components. Move it to the top level    laststance/no-nested-component-definitions
-  106:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'  laststance/no-context-provider
-  114:11  warning  Missing an explicit type attribute for button                                          laststance/no-missing-button-type
-  121:11  warning  A fragment placed inside a host component is useless                                   laststance/jsx-no-useless-fragment
-  127:13  warning  A fragment placed inside a host component is useless                                   laststance/jsx-no-useless-fragment
+   43:3   warning  Add missing 'displayName' for component                                                                                              laststance/no-missing-component-display-name
+   52:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                       laststance/no-forward-ref
+   97:3   warning  Do not nest component definitions inside other components. Move it to the top level                                                  laststance/no-nested-component-definitions
+  107:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                laststance/no-context-provider
+  115:11  warning  Missing an explicit type attribute for button                                                                                        laststance/no-missing-button-type
+  122:11  warning  A fragment placed inside a host component is useless                                                                                 laststance/jsx-no-useless-fragment
+  128:13  warning  A fragment placed inside a host component is useless                                                                                 laststance/jsx-no-useless-fragment
+  131:14  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead  laststance/no-jsx-iife
 
 <projectRoot>/src/app/page.tsx
   259:3   warning  Component "Home" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                                                                                                                            laststance/no-direct-use-effect
@@ -23,5 +24,5 @@
   330:9   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                                                                                                                     laststance/no-context-provider
   456:33  warning  Avoid prop-drilling a React.useState updater (onIncrement). It tightly couples components and can cause unnecessary re-renders due to unstable function identity. Prefer exposing a semantic handler (e.g., onIncrement) or use a state management library (e.g., Zustand, Redux, Jotai)  laststance/no-set-state-prop-drilling
 
-✖ 20 problems (0 errors, 20 warnings)
+✖ 21 problems (0 errors, 21 warnings)
   0 errors and 5 warnings potentially fixable with the `--fix` option.

--- a/apps/todo-lint-app/tests/eslint-e2e-helpers.ts
+++ b/apps/todo-lint-app/tests/eslint-e2e-helpers.ts
@@ -1,0 +1,146 @@
+import { ESLint, type LintResult } from 'eslint'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import laststancePlugin from '@laststance/react-next-eslint-plugin'
+
+export const projectRoot = fileURLToPath(new URL('..', import.meta.url))
+const ANSI_ESCAPE_SEQUENCE_PATTERN = /\u001b\[[0-9;]*m/g
+const ESLINT_VERSION = ESLint.version ?? '0.0.0'
+export const ESLINT_MAJOR_VERSION = ESLINT_VERSION.split('.')[0] ?? 'unknown'
+export const ESLINT_V10_MAJOR = '10'
+export const APP_SOURCE_GLOB = 'src'
+export const V10_COMPAT_FIXTURE_GLOB = 'tests/fixtures/eslint-v10'
+export const V10_COMPAT_FIXTURE_FILE_PATH = path.join(
+  projectRoot,
+  'tests/fixtures/eslint-v10/page.jsx',
+)
+export const SNAPSHOT_TEST_NAME = `captures plugin warnings for the demo app (eslint v${ESLINT_MAJOR_VERSION})`
+export const SNAPSHOT_DIRECTORY = path.join(
+  projectRoot,
+  'tests',
+  '__snapshots__',
+)
+export const SNAPSHOT_FILE_PATH = path.join(
+  SNAPSHOT_DIRECTORY,
+  `lint-snapshot.eslint-v${ESLINT_MAJOR_VERSION}.snap`,
+)
+export const V10_COMPAT_RULES = {
+  'laststance/no-forward-ref': 'warn',
+  'laststance/no-context-provider': 'warn',
+  'laststance/jsx-no-useless-fragment': 'warn',
+  'laststance/no-jsx-iife': 'warn',
+  'laststance/no-missing-button-type': 'warn',
+  'laststance/no-direct-use-effect': 'warn',
+  'laststance/prefer-stable-context-value': 'warn',
+}
+
+/**
+ * Removes ANSI escape sequences from terminal output.
+ * @param value - The text to sanitize.
+ * @returns
+ * - When ANSI sequences exist: cleaned text without color/format codes
+ * - When none exist: original text
+ * @example
+ * stripAnsiSequences('\u001b[31mred\u001b[0m') // => 'red'
+ */
+export function stripAnsiSequences(value: string) {
+  return value.replace(ANSI_ESCAPE_SEQUENCE_PATTERN, '')
+}
+
+/**
+ * Creates an ESLint instance for the currently installed major version.
+ * @returns
+ * - ESLint v9: project-level config linting `src/`
+ * - ESLint v10: compatibility config linting the `tests/fixtures/eslint-v10` JSX fixture set
+ * @example
+ * createEslintForCurrentMajor() // => ESLint instance bound to current major
+ */
+export function createEslintForCurrentMajor() {
+  if (ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR) {
+    return new ESLint({
+      cwd: projectRoot,
+      overrideConfigFile: true,
+      overrideConfig: [
+        {
+          files: ['tests/fixtures/eslint-v10/**/*.jsx'],
+          languageOptions: {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            parserOptions: {
+              ecmaFeatures: {
+                jsx: true,
+              },
+            },
+          },
+          plugins: {
+            laststance: laststancePlugin,
+          },
+          rules: V10_COMPAT_RULES,
+        },
+      ],
+    })
+  }
+
+  return new ESLint({ cwd: projectRoot })
+}
+
+/**
+ * Returns lint target globs for the current ESLint major version.
+ * @returns
+ * - ESLint v9: `['src']`
+ * - ESLint v10: `['tests/fixtures/eslint-v10']`
+ * @example
+ * getLintTargets() // => ['src']
+ */
+export function getLintTargets() {
+  if (ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR) {
+    return [V10_COMPAT_FIXTURE_GLOB]
+  }
+  return [APP_SOURCE_GLOB]
+}
+
+/**
+ * Lints the current major-version targets using the shared ESLint configuration.
+ * @returns
+ * - `eslint`: the ESLint instance used for linting
+ * - `results`: lint results for the current target set
+ * @example
+ * const { results } = await lintCurrentTargets()
+ */
+export async function lintCurrentTargets(): Promise<{
+  eslint: ESLint
+  results: LintResult[]
+}> {
+  const eslint = createEslintForCurrentMajor()
+  const results = await eslint.lintFiles(getLintTargets())
+
+  return { eslint, results }
+}
+
+/**
+ * Formats lint results and normalizes absolute paths and ANSI sequences.
+ * @param eslint - ESLint instance used to produce the formatter.
+ * @param results - Lint results to format.
+ * @returns
+ * - Formatted output with project-root placeholders and no ANSI codes
+ * @example
+ * const output = await createNormalizedLintOutput(eslint, results)
+ */
+export async function createNormalizedLintOutput(
+  eslint: ESLint,
+  results: LintResult[],
+) {
+  const formatter = await eslint.loadFormatter('stylish')
+  const output = formatter.format(results)
+  const projectRootNoTrailingSep = projectRoot.endsWith(path.sep)
+    ? projectRoot.slice(0, -path.sep.length)
+    : projectRoot
+
+  return stripAnsiSequences(
+    output
+      .split(`${projectRootNoTrailingSep}${path.sep}`)
+      .join('<projectRoot>/')
+      .split(projectRootNoTrailingSep)
+      .join('<projectRoot>'),
+  )
+}

--- a/apps/todo-lint-app/tests/fixtures/eslint-v10/page.jsx
+++ b/apps/todo-lint-app/tests/fixtures/eslint-v10/page.jsx
@@ -4,7 +4,11 @@ const ThemeContext = createContext({ mode: 'light' })
 const USELESS_FRAGMENT_LABEL = 'Useless fragment text'
 
 const ForwardedButton = forwardRef(function ForwardedButton(_props, ref) {
-  return <button ref={ref}>Forwarded</button>
+  return (
+    <button ref={ref} type="button">
+      Forwarded
+    </button>
+  )
 })
 
 export default function V10CompatFixture() {
@@ -14,6 +18,7 @@ export default function V10CompatFixture() {
     <ThemeContext.Provider value={{ mode: 'dark' }}>
       <button>Missing button type</button>
       <ForwardedButton />
+      <p>{(() => 'JSX IIFE')()}</p>
       <div>
         <>{USELESS_FRAGMENT_LABEL}</>
       </div>

--- a/apps/todo-lint-app/tests/lint-focused.test.ts
+++ b/apps/todo-lint-app/tests/lint-focused.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createEslintForCurrentMajor,
+  ESLINT_MAJOR_VERSION,
+  ESLINT_V10_MAJOR,
+  V10_COMPAT_FIXTURE_FILE_PATH,
+  V10_COMPAT_FIXTURE_GLOB,
+} from './eslint-e2e-helpers'
+
+const EXPECTED_RESULT_COUNT = 1
+const EXPECTED_MESSAGE_COUNT = 1
+const describeWhenEslintV10 =
+  ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR ? describe : describe.skip
+const REPRESENTATIVE_RULE_ASSERTIONS = [
+  {
+    ruleId: 'laststance/no-jsx-iife',
+    messageFragment:
+      'Do not use immediately invoked function expressions inside JSX.',
+  },
+  {
+    ruleId: 'laststance/no-missing-button-type',
+    messageFragment: 'Missing an explicit type attribute for button.',
+  },
+  {
+    ruleId: 'laststance/jsx-no-useless-fragment',
+    messageFragment: 'A fragment placed inside a host component is useless',
+  },
+] as const
+
+describeWhenEslintV10('ESLint focused integration assertions', () => {
+  it('reports representative compatibility rules exactly once in the v10 fixture', async () => {
+    const eslint = createEslintForCurrentMajor()
+    const results = await eslint.lintFiles([V10_COMPAT_FIXTURE_GLOB])
+
+    expect(results).toHaveLength(EXPECTED_RESULT_COUNT)
+    expect(results[0]?.filePath).toBe(V10_COMPAT_FIXTURE_FILE_PATH)
+
+    for (const ruleAssertion of REPRESENTATIVE_RULE_ASSERTIONS) {
+      const matchingMessages =
+        results[0]?.messages.filter(
+          (message) => message.ruleId === ruleAssertion.ruleId,
+        ) ?? []
+
+      expect(matchingMessages).toHaveLength(EXPECTED_MESSAGE_COUNT)
+      expect(matchingMessages[0]?.message).toContain(
+        ruleAssertion.messageFragment,
+      )
+    }
+  })
+})

--- a/apps/todo-lint-app/tests/lint-snapshot.test.ts
+++ b/apps/todo-lint-app/tests/lint-snapshot.test.ts
@@ -1,114 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { ESLint } from 'eslint'
-import { fileURLToPath } from 'node:url'
-import path from 'node:path'
-import laststancePlugin from '@laststance/react-next-eslint-plugin'
-
-const projectRoot = fileURLToPath(new URL('..', import.meta.url))
-const ANSI_ESCAPE_SEQUENCE_PATTERN = /\u001b\[[0-9;]*m/g
-const ESLINT_VERSION = ESLint.version ?? '0.0.0'
-const ESLINT_MAJOR_VERSION = ESLINT_VERSION.split('.')[0] ?? 'unknown'
-const ESLINT_V10_MAJOR = '10'
-const APP_SOURCE_GLOB = 'src'
-const V10_COMPAT_FIXTURE_GLOB = 'tests/fixtures/eslint-v10'
-const SNAPSHOT_TEST_NAME = `captures plugin warnings for the demo app (eslint v${ESLINT_MAJOR_VERSION})`
-const SNAPSHOT_DIRECTORY = path.join(projectRoot, 'tests', '__snapshots__')
-const SNAPSHOT_FILE_PATH = path.join(
-  SNAPSHOT_DIRECTORY,
-  `lint-snapshot.eslint-v${ESLINT_MAJOR_VERSION}.snap`,
-)
-const V10_COMPAT_RULES = {
-  'laststance/no-forward-ref': 'warn',
-  'laststance/no-context-provider': 'warn',
-  'laststance/jsx-no-useless-fragment': 'warn',
-  'laststance/no-missing-button-type': 'warn',
-  'laststance/no-direct-use-effect': 'warn',
-  'laststance/prefer-stable-context-value': 'warn',
-}
+import {
+  createNormalizedLintOutput,
+  lintCurrentTargets,
+  SNAPSHOT_FILE_PATH,
+  SNAPSHOT_TEST_NAME,
+} from './eslint-e2e-helpers'
 
 describe('ESLint integration snapshot', () => {
   it(SNAPSHOT_TEST_NAME, async () => {
-    const eslint = createEslintForCurrentMajor()
-    const results = await eslint.lintFiles(getLintTargets())
-    const formatter = await eslint.loadFormatter('stylish')
-    const output = formatter.format(results)
-    const projectRootNoTrailingSep = projectRoot.endsWith(path.sep)
-      ? projectRoot.slice(0, -path.sep.length)
-      : projectRoot
-
-    const normalizedOutput = stripAnsiSequences(
-      output
-        .split(`${projectRootNoTrailingSep}${path.sep}`)
-        .join('<projectRoot>/')
-        .split(projectRootNoTrailingSep)
-        .join('<projectRoot>'),
-    )
+    const { eslint, results } = await lintCurrentTargets()
+    const normalizedOutput = await createNormalizedLintOutput(eslint, results)
 
     await expect(normalizedOutput).toMatchFileSnapshot(SNAPSHOT_FILE_PATH)
   })
 })
-
-/**
- * Removes ANSI escape sequences from terminal output.
- * @param value - The text to sanitize.
- * @returns
- * - When ANSI sequences exist: cleaned text without color/format codes
- * - When none exist: original text
- * @example
- * stripAnsiSequences('\u001b[31mred\u001b[0m') // => 'red'
- */
-function stripAnsiSequences(value: string) {
-  return value.replace(ANSI_ESCAPE_SEQUENCE_PATTERN, '')
-}
-
-/**
- * Creates an ESLint instance for the currently installed major version.
- * @returns
- * - ESLint v9: project-level config (Next.js + plugin) linting `src/`
- * - ESLint v10: compatibility config linting JS fixtures only
- * @example
- * createEslintForCurrentMajor() // => ESLint instance bound to current major
- */
-function createEslintForCurrentMajor() {
-  if (ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR) {
-    return new ESLint({
-      cwd: projectRoot,
-      overrideConfigFile: true,
-      overrideConfig: [
-        {
-          files: ['tests/fixtures/eslint-v10/**/*.jsx'],
-          languageOptions: {
-            ecmaVersion: 'latest',
-            sourceType: 'module',
-            parserOptions: {
-              ecmaFeatures: {
-                jsx: true,
-              },
-            },
-          },
-          plugins: {
-            laststance: laststancePlugin,
-          },
-          rules: V10_COMPAT_RULES,
-        },
-      ],
-    })
-  }
-
-  return new ESLint({ cwd: projectRoot })
-}
-
-/**
- * Returns lint target globs for the current ESLint major version.
- * @returns
- * - ESLint v9: `['src']`
- * - ESLint v10: `['tests/fixtures/eslint-v10']`
- * @example
- * getLintTargets() // => ['src']
- */
-function getLintTargets() {
-  if (ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR) {
-    return [V10_COMPAT_FIXTURE_GLOB]
-  }
-  return [APP_SOURCE_GLOB]
-}

--- a/docs/demo-playground.md
+++ b/docs/demo-playground.md
@@ -1,11 +1,18 @@
-# Demo Playground & Snapshot Workflow
+# Demo Playground & ESLint E2E Workflow
 
-The `apps/todo-lint-app` workspace package acts as an end-to-end playground that runs the published ESLint plugin against intentionally noisy source files. The Vitest suite (`tests/lint-snapshot.test.ts`) lints `src/` and stores the formatted ESLint output in `tests/__snapshots__/lint-snapshot.test.ts.snap`.
+The `apps/todo-lint-app` workspace package acts as an end-to-end playground that runs the published ESLint plugin against intentionally noisy source files.
+In this repository, "E2E" means "run the real ESLint engine against a real app-style workspace that consumes the local plugin."
+
+The app now has two ESLint E2E suites:
+
+- `tests/lint-snapshot.test.ts`: captures the full formatted ESLint output as a snapshot
+- `tests/lint-focused.test.ts`: asserts representative rules directly from `LintResult[]`
 
 Snapshot keys are now generated per ESLint major version (for example, `eslint v9` and `eslint v10`) so CI can validate both compatibility targets independently.
 
 - ESLint v9 snapshot lints `src/` with the full demo app config.
 - ESLint v10 snapshot uses `tests/fixtures/eslint-v10/` with a plugin-only compatibility config while the Next.js ESLint stack catches up to v10.
+- ESLint v10 focused assertions verify representative compatibility rules directly: `no-jsx-iife`, `no-missing-button-type`, and `jsx-no-useless-fragment`.
 
 ## When the Snapshot Needs Updates
 
@@ -17,21 +24,36 @@ Update the stored snapshot whenever any of the following change:
 
 Avoid committing snapshot churn for unrelated file edits—if the snapshot diff looks unexpected, rerun the suite without `--update` and investigate.
 
-## How to Refresh the Snapshot
+## How to Run the ESLint E2E Suite
 
 1. Make sure the repository is already built/installed (`pnpm install` at the workspace root).
 2. From the repo root, run:
 
    ```bash
-   pnpm --filter todo-lint-app test -- --update
+   pnpm --filter todo-lint-app test:e2e
    ```
 
-   This executes the Vitest runner inside the demo app and rewrites the stored snapshot with the current ESLint output.
-3. Inspect the diff in `apps/todo-lint-app/tests/__snapshots__/lint-snapshot.test.ts.snap` to confirm the new warnings match expectations.
-4. Re-run the suite without `--update` to ensure the snapshot is now stable:
+   This executes the app-level ESLint E2E suite, including the snapshot test and any focused assertions that apply to the current ESLint major version.
+
+You can also run the root alias:
+
+```bash
+pnpm test:todo-e2e
+```
+
+## How to Refresh the Snapshot
+
+1. Run the app E2E suite with snapshot updates enabled:
 
    ```bash
-   pnpm --filter todo-lint-app test
+   pnpm --filter todo-lint-app test:e2e --update
+   ```
+
+2. Inspect the diff in `apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap` or `apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v10.snap` to confirm the new warnings match expectations.
+3. Re-run the suite without `--update` to ensure the snapshot is now stable:
+
+   ```bash
+   pnpm --filter todo-lint-app test:e2e
    ```
 
 ## Review Checklist
@@ -39,3 +61,4 @@ Avoid committing snapshot churn for unrelated file edits—if the snapshot diff 
 - Snapshot changes should be paired with code or rule changes that explain why the output shifted.
 - Include a note in your PR/commit summary (e.g., "refresh E2E lint snapshot") whenever the snapshot updates.
 - If a rule message change intentionally alters copy, double-check that docs and README examples stay in sync.
+- If a representative v10 rule stops matching, update the focused assertions only when the fixture or intended compatibility scope has truly changed.

--- a/docs/demo-playground.md
+++ b/docs/demo-playground.md
@@ -10,9 +10,9 @@ The app now has two ESLint E2E suites:
 
 Snapshot keys are now generated per ESLint major version (for example, `eslint v9` and `eslint v10`) so CI can validate both compatibility targets independently.
 
-- ESLint v9 snapshot lints `src/` with the full demo app config.
-- ESLint v10 snapshot uses `tests/fixtures/eslint-v10/` with a plugin-only compatibility config while the Next.js ESLint stack catches up to v10.
-- ESLint v10 focused assertions verify representative compatibility rules directly: `no-jsx-iife`, `no-missing-button-type`, and `jsx-no-useless-fragment`.
+- The v9 snapshot lints `src/` using the full demo app config.
+- For v10, the snapshot targets `tests/fixtures/eslint-v10/` with a plugin-only compatibility config while the Next.js ESLint stack catches up.
+- Focused v10 assertions verify representative compatibility rules directly: `no-jsx-iife`, `no-missing-button-type`, and `jsx-no-useless-fragment`.
 
 ## When the Snapshot Needs Updates
 

--- a/docs/rules/no-jsx-iife.md
+++ b/docs/rules/no-jsx-iife.md
@@ -1,0 +1,30 @@
+# no-jsx-iife
+
+🔧 [Rule Source](../../lib/rules/no-jsx-iife.js)
+
+## Rule Details
+
+This rule disallows immediately invoked function expressions inside JSX.
+Move the computation outside JSX, then reference the resulting value in the template.
+
+### ❌ Incorrect
+
+```jsx
+<div>{(() => 'x')()}</div>
+
+<Button label={(() => computeLabel())()} />
+```
+
+### ✅ Correct
+
+```jsx
+const label = computeLabel()
+
+<div>{label}</div>
+
+<Button label={label} />
+```
+
+## Options
+
+This rule has no options.

--- a/docs/rules/no-jsx-iife.md
+++ b/docs/rules/no-jsx-iife.md
@@ -10,14 +10,17 @@ Move the computation outside JSX, then reference the resulting value in the temp
 ### ❌ Incorrect
 
 ```jsx
+// Inline IIFE inside JSX — harder to read and re-evaluates on every render.
 <div>{(() => 'x')()}</div>
 
+// Wrapping a call in an IIFE hides the real computation behind an extra closure.
 <Button label={(() => computeLabel())()} />
 ```
 
 ### ✅ Correct
 
 ```jsx
+// Extract the value once outside JSX so the template only references it.
 const label = computeLabel()
 
 <div>{label}</div>

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ export interface LaststanceRuleModules {
   'no-missing-key': Rule.RuleModule
   'no-duplicate-key': Rule.RuleModule
   'jsx-no-useless-fragment': Rule.RuleModule
+  'no-jsx-iife': Rule.RuleModule
   'no-missing-component-display-name': Rule.RuleModule
   'no-nested-component-definitions': Rule.RuleModule
   'no-missing-button-type': Rule.RuleModule

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ import noContextProvider from './lib/rules/no-context-provider.js'
 import noMissingKey from './lib/rules/no-missing-key.js'
 import noDuplicateKey from './lib/rules/no-duplicate-key.js'
 import jsxNoUselessFragment from './lib/rules/jsx-no-useless-fragment.js'
+import noJsxIife from './lib/rules/no-jsx-iife.js'
 import noMissingComponentDisplayName from './lib/rules/no-missing-component-display-name.js'
 import noNestedComponentDefinitions from './lib/rules/no-nested-component-definitions.js'
 import noMissingButtonType from './lib/rules/no-missing-button-type.js'
@@ -51,12 +52,14 @@ const plugin = {
     'no-missing-key': noMissingKey,
     'no-duplicate-key': noDuplicateKey,
     'jsx-no-useless-fragment': jsxNoUselessFragment,
+    'no-jsx-iife': noJsxIife,
     'no-missing-component-display-name': noMissingComponentDisplayName,
     'no-nested-component-definitions': noNestedComponentDefinitions,
     'no-missing-button-type': noMissingButtonType,
     'prefer-stable-context-value': preferStableContextValue,
     'prefer-usecallback-might-work': usecallbackMightWork,
-    'prefer-usecallback-for-memoized-component': usecallbackForMemoizedComponent,
+    'prefer-usecallback-for-memoized-component':
+      usecallbackForMemoizedComponent,
     'prefer-usememo-for-memoized-component': usememoForMemoizedComponent,
     'prefer-usememo-might-work': usememoMightWork,
   },

--- a/lib/rules/no-jsx-iife.js
+++ b/lib/rules/no-jsx-iife.js
@@ -2,7 +2,7 @@
  * Determines whether an expression is a directly invoked function expression inside JSX.
  * @param {import('estree').Expression | import('estree').JSXEmptyExpression | null | undefined} expression - Expression to inspect.
  * @returns
- * - `true`: the expression is a `CallExpression` whose callee is an arrow/function expression
+ * - `true`: the expression is a `CallExpression` (including optional-call inside `ChainExpression`) whose callee is an arrow/function expression
  * - `false`: the expression is anything else
  * @example
  * isImmediatelyInvokedFunctionExpression({
@@ -11,11 +11,17 @@
  * }) // => true
  */
 function isImmediatelyInvokedFunctionExpression(expression) {
+  // Unwrap ChainExpression so optional-call IIFEs like `(() => 'x')?.()` are caught.
+  const target =
+    expression && expression.type === 'ChainExpression'
+      ? expression.expression
+      : expression
+
   return Boolean(
-    expression &&
-    expression.type === 'CallExpression' &&
-    (expression.callee.type === 'ArrowFunctionExpression' ||
-      expression.callee.type === 'FunctionExpression'),
+    target &&
+      target.type === 'CallExpression' &&
+      (target.callee.type === 'ArrowFunctionExpression' ||
+        target.callee.type === 'FunctionExpression'),
   )
 }
 

--- a/lib/rules/no-jsx-iife.js
+++ b/lib/rules/no-jsx-iife.js
@@ -1,0 +1,61 @@
+/**
+ * Determines whether an expression is a directly invoked function expression inside JSX.
+ * @param {import('estree').Expression | import('estree').JSXEmptyExpression | null | undefined} expression - Expression to inspect.
+ * @returns
+ * - `true`: the expression is a `CallExpression` whose callee is an arrow/function expression
+ * - `false`: the expression is anything else
+ * @example
+ * isImmediatelyInvokedFunctionExpression({
+ *   type: 'CallExpression',
+ *   callee: { type: 'ArrowFunctionExpression' },
+ * }) // => true
+ */
+function isImmediatelyInvokedFunctionExpression(expression) {
+  return Boolean(
+    expression &&
+    expression.type === 'CallExpression' &&
+    (expression.callee.type === 'ArrowFunctionExpression' ||
+      expression.callee.type === 'FunctionExpression'),
+  )
+}
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow immediately invoked function expressions inside JSX.',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/laststance/react-next-eslint-plugin/blob/main/docs/rules/no-jsx-iife.md',
+    },
+    schema: [],
+    messages: {
+      noJsxIife:
+        'Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead.',
+    },
+  },
+
+  /**
+   * Creates rule listeners for JSX expression containers.
+   * @param {import('eslint').Rule.RuleContext} context - ESLint rule context.
+   * @returns
+   * - `RuleListener`: listeners that report directly invoked function expressions inside JSX
+   * @example
+   * create(context) // => { JSXExpressionContainer(node) { ... } }
+   */
+  create(context) {
+    return {
+      JSXExpressionContainer(node) {
+        if (!isImmediatelyInvokedFunctionExpression(node.expression)) {
+          return
+        }
+
+        context.report({
+          node: node.expression,
+          messageId: 'noJsxIife',
+        })
+      },
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "test": "mocha tests/**/*.test.js",
     "test:watch": "npm test -- --watch",
-    "test:todo-e2e": "pnpm --filter todo-lint-app test",
+    "test:todo-e2e": "pnpm --filter todo-lint-app test:e2e",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/tests/lib/rules/no-jsx-iife.test.js
+++ b/tests/lib/rules/no-jsx-iife.test.js
@@ -1,0 +1,93 @@
+import { RuleTester } from 'eslint'
+import rule from '../../../lib/rules/no-jsx-iife.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2024,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('no-jsx-iife', rule, {
+  valid: [
+    {
+      code: `
+        function Component({ value }) {
+          return <div>{value}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function renderLabel() {
+          return 'label';
+        }
+
+        function Component() {
+          return <div>{renderLabel()}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          return <Button onClick={() => doThing()} />;
+        }
+      `,
+    },
+    {
+      code: `
+        const label = (() => 'ready')();
+
+        function Component() {
+          return <Button label={label} />;
+        }
+      `,
+    },
+    {
+      code: `
+        const result = (() => 'outside')();
+        console.log(result);
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Component() {
+          return <div>{(() => 'x')()}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Component() {
+          return <div>{(function () { return 'x'; })()}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Component() {
+          return <Button label={(() => 'x')()} />;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Component() {
+          return <input value={(function () { return 'x'; })()} />;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+  ],
+})

--- a/tests/lib/rules/no-jsx-iife.test.js
+++ b/tests/lib/rules/no-jsx-iife.test.js
@@ -55,6 +55,32 @@ ruleTester.run('no-jsx-iife', rule, {
         console.log(result);
       `,
     },
+    {
+      code: `
+        function Component() {
+          const compute = () => 'ok'
+          return <div>{compute()}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          function renderInner() {
+            const value = (() => 'outside-jsx')()
+            return value
+          }
+          return <div>{renderInner()}</div>;
+        }
+      `,
+    },
+    {
+      code: `
+        function Component() {
+          return <div />;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -85,6 +111,33 @@ ruleTester.run('no-jsx-iife', rule, {
       code: `
         function Component() {
           return <input value={(function () { return 'x'; })()} />;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Component() {
+          return <div>{(() => 'x')?.()}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Component() {
+          return <Button label={(function () { return 'x'; })?.()} />;
+        }
+      `,
+      errors: [{ messageId: 'noJsxIife' }],
+    },
+    {
+      code: `
+        function Outer() {
+          function Inner() {
+            return <div>{(() => 'nested')()}</div>;
+          }
+          return <Inner />;
         }
       `,
       errors: [{ messageId: 'noJsxIife' }],


### PR DESCRIPTION
## Summary
- add the new `laststance/no-jsx-iife` rule with tests, typings, docs, and demo app coverage
- strengthen the apps-based ESLint E2E flow with shared helpers plus focused v10 assertions
- expand the README section for `no-jsx-iife` with clearer incorrect/correct examples

## Testing
- `pnpm test`
- `pnpm typecheck`
- `pnpm --filter todo-lint-app lint`
- `pnpm --filter todo-lint-app test`
- `pnpm --filter todo-lint-app test:e2e`
- `pnpm test:todo-e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `no-jsx-iife` ESLint rule to prevent immediately invoked function expressions within JSX templates.
  * Enhanced E2E testing infrastructure with multi-version ESLint snapshot and focused assertion tests.

* **Documentation**
  * Added rule documentation with examples for the new `no-jsx-iife` rule.
  * Updated demo playground guide with E2E testing workflow instructions.

* **Tests**
  * Added comprehensive test coverage for the new ESLint rule.
  * Added E2E test suite with snapshot and focused test variants.

* **Chores**
  * Updated CI workflow naming for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->