### PR TITLE
feat(rule): prohibit React context and deep prop drilling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @laststance/react-next-eslint-plugin
 
-ESLint plugin for React and Next.js projects that includes one rule for my personal use and a rule to prevent infinite re-renders during Vibe Coding.
+An opinionated ESLint plugin for React and Next.js projects with rules for safer component structure, state flow, and rendering behavior.
 
 <p align="center">
   <img src="./image.png" alt="ESLint plugin preview" />
@@ -36,6 +36,8 @@ export default [
       '@laststance/react-next/no-jsx-without-return': 'error',
       '@laststance/react-next/all-memo': 'error',
       '@laststance/react-next/no-use-reducer': 'error',
+      '@laststance/react-next/no-react-context': 'error',
+      '@laststance/react-next/no-prop-drilling': 'error',
       '@laststance/react-next/no-set-state-prop-drilling': [
         'error',
         { depth: 1 },
@@ -77,6 +79,8 @@ Some rules are imported and adapted from https://github.com/jsx-eslint/eslint-pl
 - [`laststance/no-jsx-without-return`](docs/rules/no-jsx-without-return.md): Disallow JSX elements not returned or assigned
 - [`laststance/all-memo`](docs/rules/all-memo.md): Enforce wrapping React function components with `React.memo`
 - [`laststance/no-use-reducer`](docs/rules/no-use-reducer.md): Disallow `useReducer` hook in favor of Redux Toolkit to eliminate bugs
+- [`laststance/no-react-context`](docs/rules/no-react-context.md): Disallow React `createContext` and `useContext` APIs
+- [`laststance/no-prop-drilling`](docs/rules/no-prop-drilling.md): Disallow forwarding received props through two or more same-file component levels
 - [`laststance/no-set-state-prop-drilling`](docs/rules/no-set-state-prop-drilling.md): Disallow passing `useState` setters via props; prefer semantic handlers or state management
 - [`laststance/no-deopt-use-callback`](docs/rules/no-deopt-use-callback.md): Flag meaningless `useCallback` usage with intrinsic elements or inline calls
 - [`laststance/no-deopt-use-memo`](docs/rules/no-deopt-use-memo.md): Flag meaningless `useMemo` usage with intrinsic elements or inline handlers
@@ -304,6 +308,71 @@ function Counter() {
   )
 }
 ```
+
+### `no-react-context`
+
+This rule disallows React's `createContext` and `useContext` APIs. Prefer explicit props, component composition, or an external state store so dependencies and update boundaries remain visible.
+
+**❌ Incorrect**
+
+```javascript
+import { createContext, useContext } from 'react'
+
+const ThemeContext = createContext('light')
+
+function ThemeLabel() {
+  const theme = useContext(ThemeContext)
+  return <span>{theme}</span>
+}
+```
+
+The rule also catches aliases (including chained React namespace aliases), `React.createContext`, `React.useContext`, namespace imports, CommonJS `require('react')`, and TypeScript `import React = require('react')` access.
+
+**✅ Correct**
+
+```javascript
+function ThemeLabel({ theme }) {
+  return <span>{theme}</span>
+}
+
+function Page() {
+  return <ThemeLabel theme="light" />
+}
+```
+
+### `no-prop-drilling`
+
+This rule allows one same-file component boundary, then reports the second and every later boundary that forwards the same received prop. Intrinsic elements and imported components naturally stop the same-file component graph, so no library allowlist is required.
+
+**❌ Incorrect**
+
+```javascript
+function Parent({ value }) {
+  return <Child value={value} />
+}
+
+function Child({ value }) {
+  return <Grandchild value={value} /> // Second boundary: reported
+}
+
+function Grandchild({ value }) {
+  return <span>{value}</span>
+}
+```
+
+**✅ Correct**
+
+```javascript
+function Parent({ value }) {
+  return <Child value={value} /> // First boundary: allowed
+}
+
+function Child({ value }) {
+  return <span>{value}</span>
+}
+```
+
+The rule also follows parameter/body destructuring, static `props.value` access, simple aliases, JSX spreads, property reads such as `user.name`, conditional returns, React `memo` wrappers, and React `createElement`. Imported components stop propagation because the rule intentionally analyzes one file at a time.
 
 ### `no-set-state-prop-drilling`
 

--- a/apps/todo-lint-app/eslint.config.mjs
+++ b/apps/todo-lint-app/eslint.config.mjs
@@ -17,6 +17,8 @@ const eslintConfig = defineConfig([
     },
     rules: {
       'laststance/no-forward-ref': 'warn',
+      'laststance/no-react-context': 'warn',
+      'laststance/no-prop-drilling': 'warn',
       'laststance/no-context-provider': 'warn',
       'laststance/no-missing-key': 'warn',
       'laststance/no-duplicate-key': 'warn',

--- a/apps/todo-lint-app/src/app/invalid/page.tsx
+++ b/apps/todo-lint-app/src/app/invalid/page.tsx
@@ -81,9 +81,11 @@ function DuplicateKeyList() {
  * @example
  * <PropDrillingParent value="Example" />
  */
-function PropDrillingParent({ value }: PropDrillingProps) {
+const PropDrillingParent = memo(function PropDrillingParent({
+  value,
+}: PropDrillingProps) {
   return <PropDrillingChild value={value} />
-}
+})
 
 /**
  * Completes the deliberate prop-drilling violation so demo lint snapshots cover the rule.
@@ -94,10 +96,12 @@ function PropDrillingParent({ value }: PropDrillingProps) {
  * @example
  * <PropDrillingChild value="Example" />
  */
-function PropDrillingChild({ value }: PropDrillingProps) {
+const PropDrillingChild = memo(function PropDrillingChild({
+  value,
+}: PropDrillingProps) {
   // This second forwarding edge intentionally demonstrates the lint violation.
   return <PropDrillingGrandchild value={value} />
-}
+})
 
 /**
  * Renders the prop-drilling demo value after the invalid second forwarding boundary.
@@ -108,9 +112,11 @@ function PropDrillingChild({ value }: PropDrillingProps) {
  * @example
  * <PropDrillingGrandchild value="Example" />
  */
-function PropDrillingGrandchild({ value }: PropDrillingProps) {
+const PropDrillingGrandchild = memo(function PropDrillingGrandchild({
+  value,
+}: PropDrillingProps) {
   return <div className="rounded-lg border border-red-300 p-3">{value}</div>
-}
+})
 
 /**
  * Renders list items without keys to trigger missing key warnings.

--- a/apps/todo-lint-app/src/app/invalid/page.tsx
+++ b/apps/todo-lint-app/src/app/invalid/page.tsx
@@ -11,6 +11,7 @@ const MISSING_TYPE_LABEL = 'Missing type'
 const USELESS_FRAGMENT_SINGLE_CHILD_LABEL = 'Single child wrapped by fragment'
 const USELESS_FRAGMENT_HOST_LABEL = 'Host wrapper fragment'
 const JSX_IIFE_LABEL = 'JSX IIFE label'
+const PROP_DRILLING_VALUE = 'Forwarded through two component levels'
 
 type ThemeValue = {
   theme: string
@@ -19,6 +20,10 @@ type ThemeValue = {
 type Item = {
   id: number
   label: string
+}
+
+type PropDrillingProps = {
+  value: string
 }
 
 const THEME_CONTEXT_VALUE: ThemeValue = {
@@ -65,6 +70,46 @@ function DuplicateKeyList() {
       <li key={DUPLICATE_KEY_VALUE}>Duplicate B</li>
     </ul>
   )
+}
+
+/**
+ * Starts the deliberate two-level prop chain rendered by the invalid playground page.
+ * @param props - Component props.
+ * @param props.value - Value forwarded to the child component.
+ * @returns
+ * - The first allowed component boundary
+ * @example
+ * <PropDrillingParent value="Example" />
+ */
+function PropDrillingParent({ value }: PropDrillingProps) {
+  return <PropDrillingChild value={value} />
+}
+
+/**
+ * Completes the deliberate prop-drilling violation so demo lint snapshots cover the rule.
+ * @param props - Component props.
+ * @param props.value - Value received from the parent component.
+ * @returns
+ * - The second component boundary that the rule reports
+ * @example
+ * <PropDrillingChild value="Example" />
+ */
+function PropDrillingChild({ value }: PropDrillingProps) {
+  // This second forwarding edge intentionally demonstrates the lint violation.
+  return <PropDrillingGrandchild value={value} />
+}
+
+/**
+ * Renders the prop-drilling demo value after the invalid second forwarding boundary.
+ * @param props - Component props.
+ * @param props.value - Drilled value displayed by the leaf component.
+ * @returns
+ * - A visible prop-drilling example
+ * @example
+ * <PropDrillingGrandchild value="Example" />
+ */
+function PropDrillingGrandchild({ value }: PropDrillingProps) {
+  return <div className="rounded-lg border border-red-300 p-3">{value}</div>
 }
 
 /**
@@ -131,6 +176,7 @@ export default function InvalidPage() {
             {(() => JSX_IIFE_LABEL)()}
           </div>
           <NestedBadge />
+          <PropDrillingParent value={PROP_DRILLING_VALUE} />
         </section>
       </ThemeContext.Provider>
     </main>

--- a/apps/todo-lint-app/src/app/valid/page.tsx
+++ b/apps/todo-lint-app/src/app/valid/page.tsx
@@ -1,31 +1,20 @@
-import { createContext, memo, type Ref } from 'react'
+import { memo, type Ref } from 'react'
 
-const THEME_LIGHT = 'light'
 const PRODUCT_ID_ALPHA = 1
 const PRODUCT_ID_BETA = 2
 const PRODUCT_LABEL_ALPHA = 'Alpha'
 const PRODUCT_LABEL_BETA = 'Beta'
 const BUTTON_LABEL = 'Confirm'
 
-type ThemeValue = {
-  theme: string
-}
-
 type Product = {
   id: number
   label: string
-}
-
-const THEME_CONTEXT_VALUE: ThemeValue = {
-  theme: THEME_LIGHT,
 }
 
 const PRODUCTS: Product[] = [
   { id: PRODUCT_ID_ALPHA, label: PRODUCT_LABEL_ALPHA },
   { id: PRODUCT_ID_BETA, label: PRODUCT_LABEL_BETA },
 ]
-
-const ThemeContext = createContext<ThemeValue>(THEME_CONTEXT_VALUE)
 
 const MemoizedProductList = memo(ProductList)
 
@@ -39,16 +28,14 @@ const MemoizedProductList = memo(ProductList)
 export default function ValidPage() {
   return (
     <main className="min-h-screen bg-slate-50 p-8 text-slate-900">
-      <ThemeContext value={THEME_CONTEXT_VALUE}>
-        <section className="space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
-          <h1 className="text-2xl font-bold">Valid rule examples</h1>
-          <p className="text-sm text-slate-600">
-            This page keeps the new lint rules satisfied.
-          </p>
-          <MemoizedProductList items={PRODUCTS} />
-          <RefAwareButton label={BUTTON_LABEL} />
-        </section>
-      </ThemeContext>
+      <section className="space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
+        <h1 className="text-2xl font-bold">Valid rule examples</h1>
+        <p className="text-sm text-slate-600">
+          This page keeps the new lint rules satisfied.
+        </p>
+        <MemoizedProductList items={PRODUCTS} />
+        <RefAwareButton label={BUTTON_LABEL} />
+      </section>
     </main>
   )
 }

--- a/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v10.snap
+++ b/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v10.snap
@@ -1,12 +1,14 @@
 
 <projectRoot>/tests/fixtures/eslint-v10/page.jsx
-   6:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                                                                                      laststance/no-forward-ref
-  15:3   warning  Component "V10CompatFixture" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                          laststance/no-direct-use-effect
-  18:5   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                               laststance/no-context-provider
-  18:28  warning  Avoid passing a new object literal to Context.Provider "value" on each render. Wrap it in useMemo/useCallback to provide a stable reference and prevent unnecessary context consumers re-rendering  laststance/prefer-stable-context-value
-  19:7   warning  Missing an explicit type attribute for button                                                                                                                                                       laststance/no-missing-button-type
-  21:11  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                                                                 laststance/no-jsx-iife
-  23:9   warning  A fragment placed inside a host component is useless                                                                                                                                                laststance/jsx-no-useless-fragment
+   1:17  warning  Do not use React.createContext. Prefer explicit props, component composition, or an external state store                                                                                            laststance/no-react-context
+   7:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                                                                                      laststance/no-forward-ref
+  37:34  warning  Avoid forwarding the received prop "value" through two or more component levels. Read the value closer to its owner or use composition or state management                                          laststance/no-prop-drilling
+  53:3   warning  Component "V10CompatFixture" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                          laststance/no-direct-use-effect
+  56:5   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                               laststance/no-context-provider
+  56:28  warning  Avoid passing a new object literal to Context.Provider "value" on each render. Wrap it in useMemo/useCallback to provide a stable reference and prevent unnecessary context consumers re-rendering  laststance/prefer-stable-context-value
+  57:7   warning  Missing an explicit type attribute for button                                                                                                                                                       laststance/no-missing-button-type
+  59:11  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                                                                 laststance/no-jsx-iife
+  61:9   warning  A fragment placed inside a host component is useless                                                                                                                                                laststance/jsx-no-useless-fragment
 
-✖ 7 problems (0 errors, 7 warnings)
+✖ 9 problems (0 errors, 9 warnings)
   0 errors and 2 warnings potentially fixable with the `--fix` option.

--- a/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
+++ b/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
@@ -3,13 +3,13 @@
     1:10  warning  Do not use React.createContext. Prefer explicit props, component composition, or an external state store                                                    laststance/no-react-context
    48:3   warning  Add missing 'displayName' for component                                                                                                                     laststance/no-missing-component-display-name
    57:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                                              laststance/no-forward-ref
-   99:34  warning  Avoid forwarding the received prop "value" through two or more component levels. Read the value closer to its owner or use composition or state management  laststance/no-prop-drilling
-  142:3   warning  Do not nest component definitions inside other components. Move it to the top level                                                                         laststance/no-nested-component-definitions
-  152:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                       laststance/no-context-provider
-  160:11  warning  Missing an explicit type attribute for button                                                                                                               laststance/no-missing-button-type
-  167:11  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
-  173:13  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
-  176:14  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                         laststance/no-jsx-iife
+  103:34  warning  Avoid forwarding the received prop "value" through two or more component levels. Read the value closer to its owner or use composition or state management  laststance/no-prop-drilling
+  148:3   warning  Do not nest component definitions inside other components. Move it to the top level                                                                         laststance/no-nested-component-definitions
+  158:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                       laststance/no-context-provider
+  166:11  warning  Missing an explicit type attribute for button                                                                                                               laststance/no-missing-button-type
+  173:11  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
+  179:13  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
+  182:14  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                         laststance/no-jsx-iife
 
 <projectRoot>/src/app/page.tsx
     7:3   warning  Do not use React.createContext. Prefer explicit props, component composition, or an external state store                                                                                                                                                                                  laststance/no-react-context

--- a/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
+++ b/apps/todo-lint-app/tests/__snapshots__/lint-snapshot.eslint-v9.snap
@@ -1,15 +1,19 @@
 
 <projectRoot>/src/app/invalid/page.tsx
-   43:3   warning  Add missing 'displayName' for component                                                                                              laststance/no-missing-component-display-name
-   52:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                       laststance/no-forward-ref
-   97:3   warning  Do not nest component definitions inside other components. Move it to the top level                                                  laststance/no-nested-component-definitions
-  107:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                laststance/no-context-provider
-  115:11  warning  Missing an explicit type attribute for button                                                                                        laststance/no-missing-button-type
-  122:11  warning  A fragment placed inside a host component is useless                                                                                 laststance/jsx-no-useless-fragment
-  128:13  warning  A fragment placed inside a host component is useless                                                                                 laststance/jsx-no-useless-fragment
-  131:14  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead  laststance/no-jsx-iife
+    1:10  warning  Do not use React.createContext. Prefer explicit props, component composition, or an external state store                                                    laststance/no-react-context
+   48:3   warning  Add missing 'displayName' for component                                                                                                                     laststance/no-missing-component-display-name
+   57:7   warning  In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead                                                                              laststance/no-forward-ref
+   99:34  warning  Avoid forwarding the received prop "value" through two or more component levels. Read the value closer to its owner or use composition or state management  laststance/no-prop-drilling
+  142:3   warning  Do not nest component definitions inside other components. Move it to the top level                                                                         laststance/no-nested-component-definitions
+  152:7   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                       laststance/no-context-provider
+  160:11  warning  Missing an explicit type attribute for button                                                                                                               laststance/no-missing-button-type
+  167:11  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
+  173:13  warning  A fragment placed inside a host component is useless                                                                                                        laststance/jsx-no-useless-fragment
+  176:14  warning  Do not use immediately invoked function expressions inside JSX. Move the logic outside JSX and reference the computed value instead                         laststance/no-jsx-iife
 
 <projectRoot>/src/app/page.tsx
+    7:3   warning  Do not use React.createContext. Prefer explicit props, component composition, or an external state store                                                                                                                                                                                  laststance/no-react-context
+   11:3   warning  Do not use React.useContext. Prefer explicit props, component composition, or an external state store                                                                                                                                                                                     laststance/no-react-context
   259:3   warning  Component "Home" should not call useEffect directly. Extract this effect into a well-named custom hook (e.g., useDataLoader or useSyncProfile)                                                                                                                                            laststance/no-direct-use-effect
   285:15  warning  Avoid passing a useCallback-wrapped function "meaninglessFocus" to an intrinsic element. useCallback is intended to stabilize function props for memoized components to prevent unnecessary re-renders. Prefer an inline handler or plain function instead                                laststance/no-deopt-use-callback
   286:21  warning  Avoid passing a useMemo result "uselessMemoizedStyle" to an intrinsic element. useMemo is intended to stabilize values for memoized components or expensive computations, so inline them here instead                                                                                     laststance/no-deopt-use-memo
@@ -24,5 +28,5 @@
   330:9   warning  In React 19, you can render '<Context>' as a provider instead of '<Context.Provider>'                                                                                                                                                                                                     laststance/no-context-provider
   456:33  warning  Avoid prop-drilling a React.useState updater (onIncrement). It tightly couples components and can cause unnecessary re-renders due to unstable function identity. Prefer exposing a semantic handler (e.g., onIncrement) or use a state management library (e.g., Zustand, Redux, Jotai)  laststance/no-set-state-prop-drilling
 
-✖ 21 problems (0 errors, 21 warnings)
+✖ 25 problems (0 errors, 25 warnings)
   0 errors and 5 warnings potentially fixable with the `--fix` option.

--- a/apps/todo-lint-app/tests/eslint-e2e-helpers.ts
+++ b/apps/todo-lint-app/tests/eslint-e2e-helpers.ts
@@ -26,6 +26,8 @@ export const SNAPSHOT_FILE_PATH = path.join(
 )
 export const V10_COMPAT_RULES = {
   'laststance/no-forward-ref': 'warn',
+  'laststance/no-react-context': 'warn',
+  'laststance/no-prop-drilling': 'warn',
   'laststance/no-context-provider': 'warn',
   'laststance/jsx-no-useless-fragment': 'warn',
   'laststance/no-jsx-iife': 'warn',

--- a/apps/todo-lint-app/tests/fixtures/eslint-v10/page.jsx
+++ b/apps/todo-lint-app/tests/fixtures/eslint-v10/page.jsx
@@ -2,6 +2,7 @@ import React, { createContext, forwardRef, useEffect } from 'react'
 
 const ThemeContext = createContext({ mode: 'light' })
 const USELESS_FRAGMENT_LABEL = 'Useless fragment text'
+const PROP_DRILLING_VALUE = 'Forwarded through two component levels'
 
 const ForwardedButton = forwardRef(function ForwardedButton(_props, ref) {
   return (
@@ -10,6 +11,43 @@ const ForwardedButton = forwardRef(function ForwardedButton(_props, ref) {
     </button>
   )
 })
+
+/**
+ * Starts the v10 fixture's prop chain so the next component can demonstrate the violation.
+ * @param {{ value: string }} props Component props.
+ * @returns
+ * - The first allowed component boundary
+ * @example
+ * <PropDrillingParent value="Example" />
+ */
+function PropDrillingParent({ value }) {
+  return <PropDrillingChild value={value} />
+}
+
+/**
+ * Forwards the fixture prop at depth two so ESLint v10 compatibility tests observe the rule.
+ * @param {{ value: string }} props Component props.
+ * @returns
+ * - The second component boundary reported by the rule
+ * @example
+ * <PropDrillingChild value="Example" />
+ */
+function PropDrillingChild({ value }) {
+  // This second forwarding edge intentionally demonstrates the lint violation.
+  return <PropDrillingGrandchild value={value} />
+}
+
+/**
+ * Renders the fixture prop after its deliberate two-level forwarding chain.
+ * @param {{ value: string }} props Component props.
+ * @returns
+ * - A leaf element containing the drilled value
+ * @example
+ * <PropDrillingGrandchild value="Example" />
+ */
+function PropDrillingGrandchild({ value }) {
+  return <span>{value}</span>
+}
 
 export default function V10CompatFixture() {
   useEffect(() => {}, [])
@@ -22,6 +60,7 @@ export default function V10CompatFixture() {
       <div>
         <>{USELESS_FRAGMENT_LABEL}</>
       </div>
+      <PropDrillingParent value={PROP_DRILLING_VALUE} />
     </ThemeContext.Provider>
   )
 }

--- a/apps/todo-lint-app/tests/lint-focused.test.ts
+++ b/apps/todo-lint-app/tests/lint-focused.test.ts
@@ -1,4 +1,7 @@
+import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
 import { describe, expect, it } from 'vitest'
+import laststancePlugin from '@laststance/react-next-eslint-plugin'
 import {
   createEslintForCurrentMajor,
   ESLINT_MAJOR_VERSION,
@@ -12,6 +15,14 @@ const EXPECTED_MESSAGE_COUNT = 1
 const describeWhenEslintV10 =
   ESLINT_MAJOR_VERSION === ESLINT_V10_MAJOR ? describe : describe.skip
 const REPRESENTATIVE_RULE_ASSERTIONS = [
+  {
+    ruleId: 'laststance/no-react-context',
+    messageFragment: 'Do not use React.createContext.',
+  },
+  {
+    ruleId: 'laststance/no-prop-drilling',
+    messageFragment: 'through two or more component levels',
+  },
   {
     ruleId: 'laststance/no-jsx-iife',
     messageFragment:
@@ -46,5 +57,39 @@ describeWhenEslintV10('ESLint focused integration assertions', () => {
         ruleAssertion.messageFragment,
       )
     }
+  })
+})
+
+describe('no-react-context TypeScript compatibility', () => {
+  it('reports context APIs accessed through TypeScript import-equals syntax', () => {
+    // Arrange
+    const linter = new Linter()
+    const code = `
+      import React = require('react')
+
+      React.useContext(null)
+    `
+
+    // Act
+    const messages = linter.verify(
+      code,
+      [
+        {
+          files: ['**/*.ts'],
+          languageOptions: {
+            parser: tseslint.parser,
+            parserOptions: { sourceType: 'module' },
+          },
+          plugins: { laststance: laststancePlugin },
+          rules: { 'laststance/no-react-context': 'error' },
+        },
+      ],
+      { filename: 'context.ts' },
+    )
+
+    // Assert
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.ruleId).toBe('laststance/no-react-context')
+    expect(messages[0]?.message).toContain('Do not use React.useContext.')
   })
 })

--- a/docs/demo-playground.md
+++ b/docs/demo-playground.md
@@ -12,7 +12,7 @@ Snapshot keys are now generated per ESLint major version (for example, `eslint v
 
 - The v9 snapshot lints `src/` using the full demo app config.
 - For v10, the snapshot targets `tests/fixtures/eslint-v10/` with a plugin-only compatibility config while the Next.js ESLint stack catches up.
-- Focused v10 assertions verify representative compatibility rules directly: `no-jsx-iife`, `no-missing-button-type`, and `jsx-no-useless-fragment`.
+- Focused v10 assertions verify representative compatibility rules directly: `no-react-context`, `no-prop-drilling`, `no-jsx-iife`, `no-missing-button-type`, and `jsx-no-useless-fragment`.
 
 ## When the Snapshot Needs Updates
 

--- a/docs/rules/no-prop-drilling.md
+++ b/docs/rules/no-prop-drilling.md
@@ -1,0 +1,79 @@
+# no-prop-drilling
+
+Disallow forwarding received props through two or more same-file component levels.
+
+🔧 [Rule Source](../../lib/rules/no-prop-drilling.js)
+
+## Rule Details
+
+This rule allows a component to pass a received prop to one same-file child component. It reports the next pass, and every later pass, when that child forwards the prop to another component defined in the same file.
+
+The rule tracks:
+
+- Parameter/body destructuring, rest props, and static `props.value` access
+- Renamed receiving props and simple local aliases
+- JSX prop spreads
+- Property reads such as `user.name`
+- `memo` and `React.memo` wrappers
+- `createElement` and `React.createElement`
+- JSX returned from conditional and logical expressions
+
+Intrinsic elements and imported components stop the graph naturally. The rule therefore does not need a library allowlist, but it also does not follow local components imported from another file.
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+function Parent({ value }) {
+  return <Child value={value} />
+}
+
+function Child({ value }) {
+  return <Grandchild value={value} /> // Reported at depth 2
+}
+
+function Grandchild({ value }) {
+  return <GreatGrandchild value={value} /> // Also reported after depth 2
+}
+
+function GreatGrandchild({ value }) {
+  return <span>{value}</span>
+}
+```
+
+### ✅ Correct
+
+```javascript
+function Parent({ value }) {
+  return <Child value={value} />
+}
+
+function Child({ value }) {
+  return <div data-value={value}>{value}</div>
+}
+```
+
+An imported target also ends the known same-file chain:
+
+```javascript
+import { LibraryWidget } from 'library'
+
+function Parent({ value }) {
+  return <Child value={value} />
+}
+
+function Child({ value }) {
+  return <LibraryWidget value={value} />
+}
+```
+
+## Options
+
+This rule has no options. One component level is always allowed, and forwarding at depth 2 or greater is reported.
+
+## Known Limitations
+
+- Components imported from other files are not followed.
+- Dynamic component targets and computed prop names are not followed.
+- Complex runtime data flow is outside the rule's static same-file analysis.

--- a/docs/rules/no-react-context.md
+++ b/docs/rules/no-react-context.md
@@ -1,0 +1,85 @@
+# no-react-context
+
+Disallow React's `createContext` and `useContext` APIs.
+
+🔧 [Rule Source](../../lib/rules/no-react-context.js)
+
+## Rule Details
+
+This rule keeps data dependencies and update boundaries explicit by preventing application code from creating or consuming React Context. Prefer props and component composition for local data flow, or an external state store when state must be shared broadly.
+
+The rule reports:
+
+- Named imports, including aliases
+- `React.createContext` and `React.useContext` member access
+- Default, namespace, and chained React object aliases
+- Static bracket access such as `React['useContext']`
+- CommonJS `require('react')` member access and destructuring
+- TypeScript `import React = require('react')` syntax
+
+Matching local functions, imports from non-React modules, unrelated object methods, and shadowed identifiers are allowed.
+
+## Examples
+
+### ❌ Incorrect
+
+```javascript
+import { createContext, useContext } from 'react'
+
+const ThemeContext = createContext('light')
+
+function ThemeLabel() {
+  const theme = useContext(ThemeContext)
+  return <span>{theme}</span>
+}
+```
+
+```javascript
+import React, * as ReactNamespace from 'react'
+
+React.createContext(null)
+ReactNamespace.useContext(null)
+```
+
+```javascript
+const { createContext } = require('react')
+const ReactLibrary = require('react')
+
+createContext(null)
+ReactLibrary.useContext(null)
+```
+
+### ✅ Correct
+
+```javascript
+function ThemeLabel({ theme }) {
+  return <span>{theme}</span>
+}
+
+function Page() {
+  return <ThemeLabel theme="light" />
+}
+```
+
+```javascript
+import { useSelector } from 'react-redux'
+
+function AccountName() {
+  const accountName = useSelector((state) => state.account.name)
+  return <span>{accountName}</span>
+}
+```
+
+```javascript
+import { createContext } from './custom-context.js'
+
+createContext()
+```
+
+## Options
+
+This rule has no configuration options.
+
+## When Not To Use It
+
+Do not enable this rule when React Context is an intentional part of the application's architecture, when a library API requires a Context provider, or while incrementally migrating existing Context usage.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,8 @@ export default defineConfig([
       'laststance/no-jsx-without-return': 'warn',
       'laststance/all-memo': 'warn',
       'laststance/no-use-reducer': 'warn',
+      'laststance/no-react-context': 'warn',
+      'laststance/no-prop-drilling': 'warn',
       'laststance/no-set-state-prop-drilling': 'warn',
       'laststance/no-deopt-use-callback': 'warn',
       'laststance/prefer-stable-context-value': 'warn',

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,8 @@ export interface LaststanceRuleModules {
   'no-jsx-without-return': Rule.RuleModule
   'all-memo': Rule.RuleModule
   'no-use-reducer': Rule.RuleModule
+  'no-react-context': Rule.RuleModule
+  'no-prop-drilling': Rule.RuleModule
   'no-set-state-prop-drilling': Rule.RuleModule
   'no-deopt-use-callback': Rule.RuleModule
   'no-deopt-use-memo': Rule.RuleModule

--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ const pkg = JSON.parse(
 import noJsxWithoutReturn from './lib/rules/no-jsx-without-return.js'
 import allMemo from './lib/rules/all-memo.js'
 import noUseReducer from './lib/rules/no-use-reducer.js'
+import noReactContext from './lib/rules/no-react-context.js'
+import noPropDrilling from './lib/rules/no-prop-drilling.js'
 import noSetStatePropDrilling from './lib/rules/no-set-state-prop-drilling.js'
 import noDeoptUseCallback from './lib/rules/no-deopt-use-callback.js'
 import noDeoptUseMemo from './lib/rules/no-deopt-use-memo.js'
@@ -43,6 +45,8 @@ const plugin = {
     'no-jsx-without-return': noJsxWithoutReturn,
     'all-memo': allMemo,
     'no-use-reducer': noUseReducer,
+    'no-react-context': noReactContext,
+    'no-prop-drilling': noPropDrilling,
     'no-set-state-prop-drilling': noSetStatePropDrilling,
     'no-deopt-use-callback': noDeoptUseCallback,
     'no-deopt-use-memo': noDeoptUseMemo,

--- a/lib/rules/no-prop-drilling.js
+++ b/lib/rules/no-prop-drilling.js
@@ -884,6 +884,27 @@ export default {
           expressionNode.object.type === 'Identifier'
             ? resolveIdentifierVariable(expressionNode.object)
             : null
+        const receivedObjectPropName =
+          objectVariable &&
+          componentFrame.propVariableToPropName.get(objectVariable)
+        if (receivedObjectPropName) {
+          const forwardedMemberName = !expressionNode.computed
+            ? getStaticPropertyName(expressionNode.property)
+            : expressionNode.property.type === 'Literal' &&
+                typeof expressionNode.property.value === 'string'
+              ? expressionNode.property.value
+              : ALL_PROPS_NAME
+          // Replacing a member of a destructured object prop makes that forwarded value local.
+          if (
+            hasPropsMemberWriteBefore(
+              objectVariable,
+              forwardedMemberName ?? ALL_PROPS_NAME,
+              forwardingNode,
+            )
+          ) {
+            return null
+          }
+        }
         if (objectVariable === componentFrame.propsObjectVariable) {
           if (hasBindingWriteBefore(objectVariable, forwardingNode)) return null
           let sourcePropName = null

--- a/lib/rules/no-prop-drilling.js
+++ b/lib/rules/no-prop-drilling.js
@@ -476,6 +476,28 @@ export default {
     }
 
     /**
+     * Finds the nearest function that owns a write or forwarding expression so nested callbacks stay isolated.
+     * @param {import('estree').Node | null | undefined} node The syntax node whose execution owner is needed.
+     * @returns
+     * - The nearest function declaration, expression, or arrow function
+     * - null when the node is outside every function
+     * @example
+     * getOwningFunctionNode(writeIdentifier) // => the nested callback containing that write
+     */
+    function getOwningFunctionNode(node) {
+      let currentNode = node?.parent ?? null
+      while (
+        currentNode &&
+        currentNode.type !== 'FunctionDeclaration' &&
+        currentNode.type !== 'FunctionExpression' &&
+        currentNode.type !== 'ArrowFunctionExpression'
+      ) {
+        currentNode = currentNode.parent
+      }
+      return currentNode
+    }
+
+    /**
      * Detects a non-initialization write before forwarding so replaced prop bindings lose their received origin.
      * @param {import('eslint').Scope.Variable | null} variable The prop or alias binding being inspected.
      * @param {import('estree').Node} referenceNode The forwarding expression used as the ordering boundary.
@@ -487,10 +509,12 @@ export default {
      */
     function hasBindingWriteBefore(variable, referenceNode) {
       if (!variable) return false
+      const referenceOwner = getOwningFunctionNode(referenceNode)
       return variable.references.some(
         (reference) =>
           !reference.init &&
           reference.isWrite() &&
+          getOwningFunctionNode(reference.identifier) === referenceOwner &&
           isNodeBefore(reference.identifier, referenceNode),
       )
     }
@@ -559,7 +583,11 @@ export default {
       referenceNode,
     ) {
       if (!variable) return false
+      const referenceOwner = getOwningFunctionNode(referenceNode)
       return variable.references.some((reference) => {
+        if (getOwningFunctionNode(reference.identifier) !== referenceOwner) {
+          return false
+        }
         if (!isNodeBefore(reference.identifier, referenceNode)) return false
         const mutatedPropName = getMutatedPropsName(reference.identifier)
         if (!mutatedPropName) return false
@@ -958,17 +986,9 @@ export default {
         return
       }
 
-      let owningFunctionNode = declaratorNode.parent
-      while (
-        owningFunctionNode &&
-        owningFunctionNode.type !== 'FunctionDeclaration' &&
-        owningFunctionNode.type !== 'FunctionExpression' &&
-        owningFunctionNode.type !== 'ArrowFunctionExpression'
-      ) {
-        owningFunctionNode = owningFunctionNode.parent
-      }
       // Nested callback bindings must not leak into the component's prop namespace.
-      if (owningFunctionNode !== currentComponent.node) return
+      if (getOwningFunctionNode(declaratorNode) !== currentComponent.node)
+        return
 
       const sourcePropName = resolveSourcePropName(
         declaratorNode.init,

--- a/lib/rules/no-prop-drilling.js
+++ b/lib/rules/no-prop-drilling.js
@@ -1,0 +1,1039 @@
+import { isJSX } from '../utils/jsx.js'
+import { isPascalCase } from '../utils/naming.js'
+import {
+  findVariableByName,
+  getRuleScope,
+  getRuleSourceCode,
+} from '../utils/eslint-context.js'
+
+/**
+ * @fileoverview Disallow forwarding received props through two or more component levels.
+ * @author laststance
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow forwarding received props through two or more same-file component levels.',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/laststance/react-next-eslint-plugin',
+    },
+    fixable: null,
+    hasSuggestions: false,
+    schema: [],
+    messages: {
+      noPropDrilling:
+        'Avoid forwarding the received prop "{{name}}" through two or more component levels. Read the value closer to its owner or use composition or state management.',
+    },
+  },
+
+  /**
+   * Tracks received props across same-file JSX component edges so ESLint can reject the second and later forwarding levels.
+   * @param {import('eslint').Rule.RuleContext} context The ESLint rule context that calls this rule for one source file.
+   * @returns
+   * - An ESLint visitor that records components and JSX prop passes
+   * - Reports every known same-file pass at depth two or greater on Program exit
+   * @example
+   * create(context) // => { FunctionDeclaration() {}, JSXAttribute() {}, 'Program:exit'() {} }
+   */
+  create(context) {
+    const FIRST_PARAM_INDEX = 0
+    const STACK_TOP_OFFSET = 1
+    const EMPTY_STACK_LENGTH = 0
+    const DIRECT_PROP_DEPTH = 0
+    const DEPTH_INCREMENT = 1
+    const FIRST_FORBIDDEN_DEPTH = 2
+    const ALL_PROPS_NAME = '*'
+    const CREATE_ELEMENT_TARGET_INDEX = 0
+    const CREATE_ELEMENT_PROPS_INDEX = 1
+    const MIN_CREATE_ELEMENT_ARGUMENTS = 2
+    const sourceCode = getRuleSourceCode(context)
+    const componentStack = []
+    const components = new Map()
+    const componentsByDefinitionNode = new Map()
+    const propPasses = []
+
+    /**
+     * Recognizes an unshadowed CommonJS require('react') call when namespace aliases are resolved.
+     * @param {import('estree').Node | null | undefined} node The possible require call.
+     * @returns
+     * - True only for the global require function with the React module argument
+     * - False for local require functions and other calls
+     * @example
+     * isReactRequireCall(requireCallNode) // => true for require('react')
+     */
+    function isReactRequireCall(node) {
+      if (
+        !node ||
+        node.type !== 'CallExpression' ||
+        node.callee.type !== 'Identifier' ||
+        node.callee.name !== 'require' ||
+        node.arguments.length !== 1 ||
+        node.arguments[0].type !== 'Literal' ||
+        node.arguments[0].value !== 'react'
+      ) {
+        return false
+      }
+      const requireVariable = resolveIdentifierVariable(node.callee)
+      return Boolean(
+        sourceCode.isGlobalReference(node.callee) || !requireVariable,
+      )
+    }
+
+    /**
+     * Proves a lexical variable is React's default/namespace object while following simple aliases without cycles.
+     * @param {import('eslint').Scope.Variable | null} variable The namespace candidate resolved from scope.
+     * @param {Set<import('eslint').Scope.Variable>} [visitedVariables] Variables already inspected during alias traversal.
+     * @returns
+     * - True for React default/namespace imports and require aliases
+     * - False for local objects, named imports, and cyclic aliases
+     * @example
+     * isReactNamespaceVariable(reactVariable) // => true
+     */
+    function isReactNamespaceVariable(variable, visitedVariables = new Set()) {
+      if (!variable || visitedVariables.has(variable)) return false
+      visitedVariables.add(variable)
+      return variable.defs.some((definition) => {
+        if (definition.type === 'ImportBinding') {
+          return Boolean(
+            definition.parent?.type === 'ImportDeclaration' &&
+            definition.parent.source.value === 'react' &&
+            (definition.node.type === 'ImportDefaultSpecifier' ||
+              definition.node.type === 'ImportNamespaceSpecifier'),
+          )
+        }
+        if (
+          definition.type !== 'Variable' ||
+          definition.node.type !== 'VariableDeclarator'
+        ) {
+          return false
+        }
+        const initializerNode = definition.node.init
+        if (isReactRequireCall(initializerNode)) return true
+        return Boolean(
+          initializerNode?.type === 'Identifier' &&
+          isReactNamespaceVariable(
+            resolveIdentifierVariable(initializerNode),
+            visitedVariables,
+          ),
+        )
+      })
+    }
+
+    /**
+     * Proves an expression is the React namespace before member APIs such as React.memo are recognized.
+     * @param {import('estree').Node | null | undefined} node The namespace expression before an API property.
+     * @returns
+     * - True for imported, required, aliased, or unshadowed global React objects
+     * - False for local same-shaped objects
+     * @example
+     * isReactNamespaceExpression(reactIdentifier) // => true
+     */
+    function isReactNamespaceExpression(node) {
+      if (!node) return false
+      if (isReactRequireCall(node)) return true
+      if (node.type !== 'Identifier') return false
+      const variable = resolveIdentifierVariable(node)
+      if (!variable) {
+        return node.name === 'React' && sourceCode.isGlobalReference(node)
+      }
+      return isReactNamespaceVariable(variable)
+    }
+
+    /**
+     * Proves an identifier is one named API imported from React so local same-named helpers remain valid.
+     * @param {import('estree').Identifier} identifierNode The direct call identifier.
+     * @param {string} apiName The expected React export name.
+     * @returns
+     * - True when the exact lexical binding is a matching React named import
+     * - False for local, shadowed, and non-React bindings
+     * @example
+     * isNamedReactApiIdentifier(memoIdentifier, 'memo') // => true for import { memo } from 'react'
+     */
+    function isNamedReactApiIdentifier(identifierNode, apiName) {
+      const variable = resolveIdentifierVariable(identifierNode)
+      if (!variable) return false
+      return variable.defs.some(
+        (definition) =>
+          definition.type === 'ImportBinding' &&
+          definition.parent?.type === 'ImportDeclaration' &&
+          definition.parent.source.value === 'react' &&
+          definition.node.type === 'ImportSpecifier' &&
+          definition.node.imported.type === 'Identifier' &&
+          definition.node.imported.name === apiName,
+      )
+    }
+
+    /**
+     * Recognizes one React API callee by lexical provenance rather than matching local function names.
+     * @param {import('estree').Expression | import('estree').Super} calleeNode The call expression callee.
+     * @param {string} apiName The React API expected at that call site.
+     * @returns
+     * - True for a matching React named import or namespace member
+     * - False for local and unrelated callees
+     * @example
+     * isReactApiCallee(callNode.callee, 'createElement') // => true for React.createElement
+     */
+    function isReactApiCallee(calleeNode, apiName) {
+      if (calleeNode.type === 'Identifier') {
+        return isNamedReactApiIdentifier(calleeNode, apiName)
+      }
+      if (calleeNode.type !== 'MemberExpression') return false
+      const propertyName = !calleeNode.computed
+        ? getStaticPropertyName(calleeNode.property)
+        : calleeNode.property.type === 'Literal' &&
+            typeof calleeNode.property.value === 'string'
+          ? calleeNode.property.value
+          : null
+      return (
+        propertyName === apiName &&
+        isReactNamespaceExpression(calleeNode.object)
+      )
+    }
+
+    /**
+     * Recognizes React.createElement and imported createElement calls so JSX-free components join the same graph.
+     * @param {import('estree').Node | null | undefined} node The possible call expression.
+     * @returns
+     * - True for createElement(...) and React.createElement(...)
+     * - False for every other node
+     * @example
+     * isCreateElementCall({ type: 'CallExpression', callee: { type: 'Identifier', name: 'createElement' } }) // => true
+     */
+    function isCreateElementCall(node) {
+      if (!node || node.type !== 'CallExpression') return false
+      return isReactApiCallee(node.callee, 'createElement')
+    }
+
+    /**
+     * Finds JSX/createElement inside a returned expression such as a conditional or logical branch.
+     * @param {import('estree').Node | null | undefined} node The returned expression subtree.
+     * @returns
+     * - True when the expression can produce a React element
+     * - False when no React element syntax exists or a nested function starts
+     * @example
+     * containsReactElementExpression(conditionalNode) // => true when one branch is JSX
+     */
+    function containsReactElementExpression(node) {
+      if (!node) return false
+      if (isJSX(node) || isCreateElementCall(node)) return true
+      if (
+        node.type === 'FunctionDeclaration' ||
+        node.type === 'FunctionExpression' ||
+        node.type === 'ArrowFunctionExpression'
+      ) {
+        return false
+      }
+      const childKeys = sourceCode.visitorKeys[node.type] ?? []
+      return childKeys.some((childKey) => {
+        const childValue = node[childKey]
+        if (Array.isArray(childValue)) {
+          return childValue.some((childNode) =>
+            containsReactElementExpression(childNode),
+          )
+        }
+        return containsReactElementExpression(childValue)
+      })
+    }
+
+    /**
+     * Finds JSX/createElement returns in one function's control flow while excluding nested function bodies.
+     * @param {import('estree').Node | null | undefined} node The current AST node inside the component body.
+     * @returns
+     * - True when this control-flow subtree contains a React element return
+     * - False when no matching return exists or the node starts a nested function
+     * @example
+     * containsReactElementReturn(ifStatementNode) // => true when its branch returns JSX
+     */
+    function containsReactElementReturn(node) {
+      if (!node) return false
+      if (node.type === 'ReturnStatement') {
+        return containsReactElementExpression(node.argument)
+      }
+      if (
+        node.type === 'FunctionDeclaration' ||
+        node.type === 'FunctionExpression' ||
+        node.type === 'ArrowFunctionExpression'
+      ) {
+        return false
+      }
+      const childKeys = sourceCode.visitorKeys[node.type] ?? []
+      for (const childKey of childKeys) {
+        const childValue = node[childKey]
+        if (Array.isArray(childValue)) {
+          if (
+            childValue.some((childNode) =>
+              containsReactElementReturn(childNode),
+            )
+          ) {
+            return true
+          }
+          continue
+        }
+        if (containsReactElementReturn(childValue)) return true
+      }
+      return false
+    }
+
+    /**
+     * Checks whether a function returns JSX anywhere in its own control flow so it can enter the component prop graph.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression | null | undefined} functionNode The function inspected when ESLint enters it.
+     * @returns
+     * - True when the function returns JSX or createElement from its own body
+     * - False for non-component functions or nested-function-only JSX
+     * @example
+     * functionReturnsJsx({ type: 'ArrowFunctionExpression', expression: true, body: { type: 'JSXElement' } }) // => true
+     */
+    function functionReturnsJsx(functionNode) {
+      if (!functionNode) return false
+      if (
+        functionNode.type === 'ArrowFunctionExpression' &&
+        functionNode.expression
+      ) {
+        return containsReactElementExpression(functionNode.body)
+      }
+      return containsReactElementReturn(functionNode.body)
+    }
+
+    /**
+     * Recognizes memo and React.memo wrappers so anonymous memoized components retain their variable name in the graph.
+     * @param {import('estree').Node | null | undefined} node The possible memo call wrapping a function.
+     * @returns
+     * - True for memo(...) and React.memo(...)
+     * - False for every other node
+     * @example
+     * isMemoCall({ type: 'CallExpression', callee: { type: 'Identifier', name: 'memo' } }) // => true
+     */
+    function isMemoCall(node) {
+      if (!node || node.type !== 'CallExpression') return false
+      return isReactApiCallee(node.callee, 'memo')
+    }
+
+    /**
+     * Resolves the stable PascalCase name used to connect a component definition with its JSX usages.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The function entered by ESLint.
+     * @returns
+     * - The component name for a named declaration or variable initializer
+     * - null when the function is not a tracked component
+     * @example
+     * resolveComponentName(functionNode) // => 'Child'
+     */
+    function resolveComponentName(functionNode) {
+      if (!functionReturnsJsx(functionNode)) return null
+      if (
+        functionNode.id &&
+        functionNode.id.type === 'Identifier' &&
+        isPascalCase(functionNode.id.name)
+      ) {
+        return functionNode.id.name
+      }
+
+      const parentNode = functionNode.parent
+      if (
+        parentNode &&
+        parentNode.type === 'VariableDeclarator' &&
+        parentNode.id.type === 'Identifier' &&
+        parentNode.init === functionNode &&
+        isPascalCase(parentNode.id.name)
+      ) {
+        return parentNode.id.name
+      }
+      if (
+        parentNode &&
+        isMemoCall(parentNode) &&
+        parentNode.arguments[0] === functionNode
+      ) {
+        const declaratorNode = parentNode.parent
+        if (
+          declaratorNode &&
+          declaratorNode.type === 'VariableDeclarator' &&
+          declaratorNode.id.type === 'Identifier' &&
+          isPascalCase(declaratorNode.id.name)
+        ) {
+          return declaratorNode.id.name
+        }
+      }
+      return null
+    }
+
+    /**
+     * Resolves the declaration node stored by ESLint scope definitions so JSX references connect to the exact component binding.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The tracked component function.
+     * @returns
+     * - The owning variable declarator for variable and memo components
+     * - The function node for declarations and named function bindings
+     * @example
+     * getComponentDefinitionNode(functionNode) // => variableDeclaratorNode
+     */
+    function getComponentDefinitionNode(functionNode) {
+      if (functionNode.parent?.type === 'VariableDeclarator') {
+        return functionNode.parent
+      }
+      if (
+        functionNode.parent?.type === 'CallExpression' &&
+        isMemoCall(functionNode.parent) &&
+        functionNode.parent.parent?.type === 'VariableDeclarator'
+      ) {
+        return functionNode.parent.parent
+      }
+      return functionNode
+    }
+
+    /**
+     * Unwraps a defaulted component parameter before prop bindings are collected at function entry.
+     * @param {import('estree').Pattern | null | undefined} parameterNode The first component parameter.
+     * @returns
+     * - The underlying pattern for a defaulted parameter
+     * - The original pattern or null otherwise
+     * @example
+     * normalizeParameter({ type: 'AssignmentPattern', left: { type: 'Identifier', name: 'props' } }) // => props identifier
+     */
+    function normalizeParameter(parameterNode) {
+      if (!parameterNode) return null
+      return parameterNode.type === 'AssignmentPattern'
+        ? parameterNode.left
+        : parameterNode
+    }
+
+    /**
+     * Returns a static property name while component parameters are converted into local-to-prop bindings.
+     * @param {import('estree').Expression | import('estree').Pattern | null | undefined} keyNode The property key from a pattern or object.
+     * @returns
+     * - The identifier or string literal value
+     * - null when the key is computed or dynamic
+     * @example
+     * getStaticPropertyName({ type: 'Identifier', name: 'value' }) // => 'value'
+     */
+    function getStaticPropertyName(keyNode) {
+      if (!keyNode) return null
+      if (keyNode.type === 'Identifier') return keyNode.name
+      if (keyNode.type === 'Literal' && typeof keyNode.value === 'string') {
+        return keyNode.value
+      }
+      return null
+    }
+
+    /**
+     * Resolves the identifier created by a top-level destructured prop so later references can use lexical identity.
+     * @param {import('estree').Pattern | import('estree').Expression | null | undefined} patternNode The property value pattern.
+     * @returns
+     * - The local identifier node
+     * - null for nested or unsupported patterns
+     * @example
+     * getLocalBindingIdentifier({ type: 'Identifier', name: 'localValue' }) // => localValue identifier
+     */
+    function getLocalBindingIdentifier(patternNode) {
+      if (!patternNode) return null
+      if (patternNode.type === 'Identifier') return patternNode
+      if (
+        patternNode.type === 'AssignmentPattern' &&
+        patternNode.left.type === 'Identifier'
+      ) {
+        return patternNode.left
+      }
+      return null
+    }
+
+    /**
+     * Resolves the nearest lexical variable for an identifier whenever prop or component names may be shadowed.
+     * @param {import('estree').Identifier | import('estree').JSXIdentifier | null | undefined} identifierNode The identifier reference or declaration.
+     * @returns
+     * - The nearest ESLint scope variable
+     * - null when the identifier is unresolved
+     * @example
+     * resolveIdentifierVariable(valueIdentifier) // => the component parameter variable
+     */
+    function resolveIdentifierVariable(identifierNode) {
+      if (!identifierNode) return null
+      return findVariableByName(
+        getRuleScope(context, identifierNode),
+        identifierNode.name,
+      )
+    }
+
+    /**
+     * Collects the first parameter's prop bindings when a component frame is created.
+     * @param {{ propVariableToPropName: Map<import('eslint').Scope.Variable, string>, propsObjectVariable: import('eslint').Scope.Variable | null }} componentFrame The frame being initialized.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The component function.
+     * @returns
+     * - No value; the frame is updated in place
+     * - No change when the component has no supported props parameter
+     * @example
+     * collectComponentProps(frame, functionNode) // => undefined
+     */
+    function collectComponentProps(componentFrame, functionNode) {
+      const parameterNode = normalizeParameter(
+        functionNode.params[FIRST_PARAM_INDEX],
+      )
+      if (!parameterNode) return
+      if (parameterNode.type === 'Identifier') {
+        componentFrame.propsObjectVariable =
+          resolveIdentifierVariable(parameterNode)
+        return
+      }
+      if (parameterNode.type !== 'ObjectPattern') return
+
+      for (const propertyNode of parameterNode.properties) {
+        if (
+          propertyNode.type === 'RestElement' &&
+          propertyNode.argument.type === 'Identifier'
+        ) {
+          const restVariable = resolveIdentifierVariable(propertyNode.argument)
+          if (restVariable) {
+            componentFrame.propVariableToPropName.set(
+              restVariable,
+              ALL_PROPS_NAME,
+            )
+          }
+          continue
+        }
+        // Computed properties cannot be mapped to one stable prop name.
+        if (propertyNode.type !== 'Property' || propertyNode.computed) continue
+        const propName = getStaticPropertyName(propertyNode.key)
+        const localIdentifier = getLocalBindingIdentifier(propertyNode.value)
+        const localVariable = resolveIdentifierVariable(localIdentifier)
+        if (!propName || !localVariable) continue
+        componentFrame.propVariableToPropName.set(localVariable, propName)
+      }
+    }
+
+    /**
+     * Registers a React component before its body is traversed so nested JSX passes can identify their owner.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The function entered by ESLint.
+     * @returns
+     * - No value; a tracked frame is pushed for component functions
+     * - No change for ordinary functions
+     * @example
+     * enterComponent(functionNode) // => undefined
+     */
+    function enterComponent(functionNode) {
+      const componentName = resolveComponentName(functionNode)
+      if (!componentName) return
+      const componentFrame = {
+        name: componentName,
+        node: functionNode,
+        propVariableToPropName: new Map(),
+        propsObjectVariable: null,
+      }
+      collectComponentProps(componentFrame, functionNode)
+      components.set(functionNode, componentFrame)
+      componentsByDefinitionNode.set(
+        getComponentDefinitionNode(functionNode),
+        functionNode,
+      )
+      componentStack.push(componentFrame)
+    }
+
+    /**
+     * Removes a component frame after ESLint finishes its body so later passes are attributed to the correct component.
+     * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The function exited by ESLint.
+     * @returns
+     * - No value; the matching frame is removed
+     * - No change when the function was not tracked
+     * @example
+     * leaveComponent(functionNode) // => undefined
+     */
+    function leaveComponent(functionNode) {
+      const currentFrame = componentStack.at(-STACK_TOP_OFFSET)
+      if (currentFrame && currentFrame.node === functionNode) {
+        componentStack.pop()
+      }
+    }
+
+    /**
+     * Reads the active component frame while JSX attributes are visited inside its function body.
+     * @returns
+     * - The active component frame
+     * - null outside a tracked component
+     * @example
+     * getCurrentComponent() // => { name: 'Parent', ... }
+     */
+    function getCurrentComponent() {
+      return componentStack.length > EMPTY_STACK_LENGTH
+        ? componentStack.at(-STACK_TOP_OFFSET)
+        : null
+    }
+
+    /**
+     * Resolves a PascalCase JSX identifier so its lexical binding can decide whether the target is same-file.
+     * @param {import('estree').JSXOpeningElement | null | undefined} openingElementNode The JSX opening element owning an attribute.
+     * @returns
+     * - The PascalCase JSX identifier node
+     * - null for intrinsic, member, namespaced, or unknown elements
+     * @example
+     * getJsxComponentIdentifier(openingElementNode) // => Child JSXIdentifier
+     */
+    function getJsxComponentIdentifier(openingElementNode) {
+      if (
+        !openingElementNode ||
+        openingElementNode.name.type !== 'JSXIdentifier'
+      ) {
+        return null
+      }
+      const elementName = openingElementNode.name.name
+      return isPascalCase(elementName) ? openingElementNode.name : null
+    }
+
+    /**
+     * Adds one normalized component edge so JSX and createElement recording share the same pass shape.
+     * @param {import('estree').Node} reportNode The syntax node reported when the edge reaches a forbidden depth.
+     * @param {import('estree').Node} fromComponentNode The component function forwarding the value.
+     * @param {import('estree').Identifier | import('estree').JSXIdentifier} targetIdentifierNode The component reference whose lexical binding receives the value.
+     * @param {string} targetPropName The receiving prop name or the all-props marker.
+     * @param {import('estree').Expression | import('estree').Pattern} expressionNode The forwarded expression inspected for prop origins.
+     * @returns
+     * - No value; one normalized edge is appended to the pass list
+     * @example
+     * recordPropPass(attributeNode, parentNode, childIdentifier, 'value', expressionNode) // => undefined
+     */
+    function recordPropPass(
+      reportNode,
+      fromComponentNode,
+      targetIdentifierNode,
+      targetPropName,
+      expressionNode,
+    ) {
+      propPasses.push({
+        reportNode,
+        fromComponentNode,
+        targetVariable: resolveIdentifierVariable(targetIdentifierNode),
+        targetPropName,
+        expression: expressionNode,
+      })
+    }
+
+    /**
+     * Stores each explicit JSX prop pass until all component definitions are known at Program exit.
+     * @param {import('estree').JSXAttribute} attributeNode The JSX attribute visited by ESLint.
+     * @returns
+     * - No value; a pass is appended for supported component attributes
+     * - No change for intrinsic elements or non-expression attributes
+     * @example
+     * recordJsxPropPass(attributeNode) // => undefined
+     */
+    function recordJsxPropPass(attributeNode) {
+      const currentComponent = getCurrentComponent()
+      if (!currentComponent) return
+      if (
+        !attributeNode.value ||
+        attributeNode.value.type !== 'JSXExpressionContainer'
+      ) {
+        return
+      }
+      const targetIdentifierNode = getJsxComponentIdentifier(
+        attributeNode.parent,
+      )
+      const targetPropName =
+        attributeNode.name.type === 'JSXIdentifier'
+          ? attributeNode.name.name
+          : null
+      if (!targetIdentifierNode || !targetPropName) return
+      recordPropPass(
+        attributeNode,
+        currentComponent.node,
+        targetIdentifierNode,
+        targetPropName,
+        attributeNode.value.expression,
+      )
+    }
+
+    /**
+     * Stores a JSX spread as an all-props pass so object spreading cannot reset the known component depth.
+     * @param {import('estree').JSXSpreadAttribute} spreadAttributeNode The JSX spread visited by ESLint.
+     * @returns
+     * - No value; an all-props pass is appended for a known component target
+     * - No change for intrinsic or unsupported JSX targets
+     * @example
+     * recordJsxSpreadPass(spreadAttributeNode) // => undefined
+     */
+    function recordJsxSpreadPass(spreadAttributeNode) {
+      const currentComponent = getCurrentComponent()
+      if (!currentComponent) return
+      const targetIdentifierNode = getJsxComponentIdentifier(
+        spreadAttributeNode.parent,
+      )
+      if (!targetIdentifierNode) return
+      recordPropPass(
+        spreadAttributeNode,
+        currentComponent.node,
+        targetIdentifierNode,
+        ALL_PROPS_NAME,
+        spreadAttributeNode.argument,
+      )
+    }
+
+    /**
+     * Resolves a PascalCase createElement target so only known same-file components add a drilling edge.
+     * @param {import('estree').Expression | import('estree').SpreadElement | null | undefined} targetNode The first createElement argument.
+     * @returns
+     * - The PascalCase identifier node
+     * - null for intrinsic and unsupported targets
+     * @example
+     * getCreateElementComponentIdentifier({ type: 'Identifier', name: 'Child' }) // => Child identifier
+     */
+    function getCreateElementComponentIdentifier(targetNode) {
+      if (!targetNode || targetNode.type !== 'Identifier') return null
+      return isPascalCase(targetNode.name) ? targetNode : null
+    }
+
+    /**
+     * Stores createElement object properties as component prop passes when ESLint visits JSX-free React code.
+     * @param {import('estree').CallExpression} callExpressionNode The call expression visited inside a tracked component.
+     * @returns
+     * - No value; supported props are appended to the pass list
+     * - No change for non-createElement, intrinsic, imported, or dynamic targets
+     * @example
+     * recordCreateElementPass(callExpressionNode) // => undefined
+     */
+    function recordCreateElementPass(callExpressionNode) {
+      const currentComponent = getCurrentComponent()
+      if (!currentComponent || !isCreateElementCall(callExpressionNode)) return
+      if (callExpressionNode.arguments.length < MIN_CREATE_ELEMENT_ARGUMENTS) {
+        return
+      }
+      const targetIdentifierNode = getCreateElementComponentIdentifier(
+        callExpressionNode.arguments[CREATE_ELEMENT_TARGET_INDEX],
+      )
+      const propsNode = callExpressionNode.arguments[CREATE_ELEMENT_PROPS_INDEX]
+      if (!targetIdentifierNode || propsNode.type !== 'ObjectExpression') return
+
+      for (const propertyNode of propsNode.properties) {
+        if (propertyNode.type === 'SpreadElement') {
+          recordPropPass(
+            propertyNode,
+            currentComponent.node,
+            targetIdentifierNode,
+            ALL_PROPS_NAME,
+            propertyNode.argument,
+          )
+          continue
+        }
+        // Computed keys cannot be connected to a stable receiving prop.
+        if (propertyNode.type !== 'Property' || propertyNode.computed) continue
+        const targetPropName = getStaticPropertyName(propertyNode.key)
+        if (!targetPropName) continue
+        recordPropPass(
+          propertyNode,
+          currentComponent.node,
+          targetIdentifierNode,
+          targetPropName,
+          propertyNode.value,
+        )
+      }
+    }
+
+    /**
+     * Maps a direct identifier or props.member expression back to the received prop that supplied it.
+     * @param {import('estree').Expression | null | undefined} expressionNode The JSX attribute expression.
+     * @param {{ propVariableToPropName: Map<import('eslint').Scope.Variable, string>, propsObjectVariable: import('eslint').Scope.Variable | null }} componentFrame The component containing the expression.
+     * @returns
+     * - The source prop name for a direct received-prop reference
+     * - null when the expression is not directly prop-derived
+     * @example
+     * resolveSourcePropName({ type: 'Identifier', name: 'value' }, frame) // => 'value'
+     */
+    function resolveSourcePropName(expressionNode, componentFrame) {
+      if (!expressionNode) return null
+      if (expressionNode.type === 'Identifier') {
+        const expressionVariable = resolveIdentifierVariable(expressionNode)
+        if (expressionVariable === componentFrame.propsObjectVariable) {
+          return ALL_PROPS_NAME
+        }
+        return (
+          componentFrame.propVariableToPropName.get(expressionVariable) ?? null
+        )
+      }
+      if (
+        expressionNode.type === 'MemberExpression' &&
+        expressionNode.object.type === 'Identifier' &&
+        resolveIdentifierVariable(expressionNode.object) ===
+          componentFrame.propsObjectVariable
+      ) {
+        if (
+          !expressionNode.computed &&
+          expressionNode.property.type === 'Identifier'
+        ) {
+          return expressionNode.property.name
+        }
+        if (
+          expressionNode.computed &&
+          expressionNode.property.type === 'Literal' &&
+          typeof expressionNode.property.value === 'string'
+        ) {
+          return expressionNode.property.value
+        }
+        return null
+      }
+      if (expressionNode.type === 'MemberExpression') {
+        // A nested read such as user.name remains derived from the received user prop.
+        return resolveSourcePropName(expressionNode.object, componentFrame)
+      }
+      return null
+    }
+
+    /**
+     * Records simple and destructured same-component aliases so moving prop bindings into the body cannot bypass the check.
+     * @param {import('estree').VariableDeclarator} declaratorNode The variable declaration visited before later JSX usages.
+     * @returns
+     * - No value; direct, destructured, and rest aliases are added to the active frame
+     * - No change for non-alias declarations or declarations inside nested functions
+     * @example
+     * collectPropAlias({ id: forwardedValue, init: value }) // => undefined
+     */
+    function collectPropAlias(declaratorNode) {
+      const currentComponent = getCurrentComponent()
+      if (!currentComponent || !declaratorNode.init) {
+        return
+      }
+
+      let owningFunctionNode = declaratorNode.parent
+      while (
+        owningFunctionNode &&
+        owningFunctionNode.type !== 'FunctionDeclaration' &&
+        owningFunctionNode.type !== 'FunctionExpression' &&
+        owningFunctionNode.type !== 'ArrowFunctionExpression'
+      ) {
+        owningFunctionNode = owningFunctionNode.parent
+      }
+      // Nested callback bindings must not leak into the component's prop namespace.
+      if (owningFunctionNode !== currentComponent.node) return
+
+      const sourcePropName = resolveSourcePropName(
+        declaratorNode.init,
+        currentComponent,
+      )
+      if (!sourcePropName) return
+
+      if (declaratorNode.id.type === 'Identifier') {
+        const aliasVariable = resolveIdentifierVariable(declaratorNode.id)
+        if (!aliasVariable) return
+        currentComponent.propVariableToPropName.set(
+          aliasVariable,
+          sourcePropName,
+        )
+        return
+      }
+      if (declaratorNode.id.type !== 'ObjectPattern') return
+
+      for (const propertyNode of declaratorNode.id.properties) {
+        if (
+          propertyNode.type === 'RestElement' &&
+          propertyNode.argument.type === 'Identifier'
+        ) {
+          const restVariable = resolveIdentifierVariable(propertyNode.argument)
+          if (restVariable) {
+            currentComponent.propVariableToPropName.set(
+              restVariable,
+              sourcePropName,
+            )
+          }
+          continue
+        }
+        // Computed and nested bindings do not expose one stable local variable.
+        if (propertyNode.type !== 'Property' || propertyNode.computed) continue
+        const localIdentifier = getLocalBindingIdentifier(propertyNode.value)
+        const localVariable = resolveIdentifierVariable(localIdentifier)
+        if (!localVariable) continue
+        const destructuredPropName =
+          sourcePropName === ALL_PROPS_NAME
+            ? getStaticPropertyName(propertyNode.key)
+            : sourcePropName
+        if (!destructuredPropName) continue
+        currentComponent.propVariableToPropName.set(
+          localVariable,
+          destructuredPropName,
+        )
+      }
+    }
+
+    /**
+     * Adds a bounded depth to a target prop so the fixed-point loop terminates even when components form a cycle.
+     * @param {Map<import('estree').Node, Map<string, Set<number>>>} propDepthsByComponent The accumulated component prop depths.
+     * @param {import('estree').Node} targetComponentNode The component receiving the prop.
+     * @param {string} targetPropName The receiving prop name.
+     * @param {number} depth The discovered component depth.
+     * @returns
+     * - True when a new depth was stored
+     * - False when that bounded depth was already known
+     * @example
+     * addPropDepth(depths, childNode, 'value', 1) // => true
+     */
+    function addPropDepth(
+      propDepthsByComponent,
+      targetComponentNode,
+      targetPropName,
+      depth,
+    ) {
+      const boundedDepth = Math.min(depth, FIRST_FORBIDDEN_DEPTH)
+      const componentDepths = propDepthsByComponent.get(targetComponentNode)
+      if (!componentDepths) return false
+      if (!componentDepths.has(targetPropName)) {
+        componentDepths.set(targetPropName, new Set())
+      }
+      const knownDepths = componentDepths.get(targetPropName)
+      if (knownDepths.has(boundedDepth)) return false
+      knownDepths.add(boundedDepth)
+      return true
+    }
+
+    /**
+     * Returns the direct and previously propagated depths for one received prop during graph propagation.
+     * @param {Map<import('estree').Node, Map<string, Set<number>>>} propDepthsByComponent The accumulated component prop depths.
+     * @param {import('estree').Node} componentNode The component forwarding the prop.
+     * @param {string} sourcePropName The received prop being forwarded.
+     * @returns
+     * - A set containing depth zero plus every known inbound depth
+     * - Depth zero alone when no same-file parent pass is known
+     * @example
+     * getSourceDepths(depths, childNode, 'value') // => Set([0, 1])
+     */
+    function getSourceDepths(
+      propDepthsByComponent,
+      componentNode,
+      sourcePropName,
+    ) {
+      const sourceDepths = new Set([DIRECT_PROP_DEPTH])
+      const componentDepths = propDepthsByComponent.get(componentNode)
+      if (!componentDepths) return sourceDepths
+      const relevantDepthSets = []
+      const exactDepths = componentDepths.get(sourcePropName)
+      const allPropsDepths = componentDepths.get(ALL_PROPS_NAME)
+      if (exactDepths) relevantDepthSets.push(exactDepths)
+      if (sourcePropName !== ALL_PROPS_NAME && allPropsDepths) {
+        relevantDepthSets.push(allPropsDepths)
+      }
+      if (sourcePropName === ALL_PROPS_NAME) {
+        // A spread forwards every exact prop that entered this component.
+        relevantDepthSets.push(...componentDepths.values())
+      }
+      for (const relevantDepths of relevantDepthSets) {
+        for (const knownDepth of relevantDepths) {
+          sourceDepths.add(knownDepth)
+        }
+      }
+      return sourceDepths
+    }
+
+    /**
+     * Connects a JSX/createElement binding to its tracked same-file component definition without name collisions.
+     * @param {import('eslint').Scope.Variable | null} targetVariable The lexical variable referenced by the component target.
+     * @returns
+     * - The tracked component function declared by that exact variable
+     * - null for imports, globals, and untracked definitions
+     * @example
+     * resolveTargetComponentNode(childVariable) // => childFunctionNode
+     */
+    function resolveTargetComponentNode(targetVariable) {
+      if (!targetVariable) return null
+      for (const definition of targetVariable.defs) {
+        const componentNode = componentsByDefinitionNode.get(definition.node)
+        if (componentNode) return componentNode
+      }
+      return null
+    }
+
+    /**
+     * Resolves one recorded edge into the source prop and depths shared by propagation and reporting.
+     * @param {{ fromComponentNode: import('estree').Node, targetVariable: import('eslint').Scope.Variable | null, expression: import('estree').Expression }} propPass The recorded component edge.
+     * @param {Map<import('estree').Node, Map<string, Set<number>>>} propDepthsByComponent The accumulated component prop depths.
+     * @returns
+     * - The source component, target node, prop name, and known source depths
+     * - null when the edge cannot be connected to a same-file prop chain
+     * @example
+     * resolvePropPass(propPass, depths) // => { sourceComponent, targetComponentNode, sourcePropName, sourceDepths }
+     */
+    function resolvePropPass(propPass, propDepthsByComponent) {
+      const sourceComponent = components.get(propPass.fromComponentNode)
+      const targetComponentNode = resolveTargetComponentNode(
+        propPass.targetVariable,
+      )
+      if (!sourceComponent || !targetComponentNode) return null
+      const sourcePropName = resolveSourcePropName(
+        propPass.expression,
+        sourceComponent,
+      )
+      if (!sourcePropName) return null
+      return {
+        sourceComponent,
+        targetComponentNode,
+        sourcePropName,
+        sourceDepths: getSourceDepths(
+          propDepthsByComponent,
+          sourceComponent.node,
+          sourcePropName,
+        ),
+      }
+    }
+
+    /**
+     * Propagates received-prop depths until stable, then reports passes that occur at the second or later component boundary.
+     * @returns
+     * - No value; violations are reported through the ESLint context
+     * - No reports when no same-file chain reaches depth two
+     * @example
+     * analyzePropPasses() // => undefined
+     */
+    function analyzePropPasses() {
+      const propDepthsByComponent = new Map()
+      for (const componentFrame of components.values()) {
+        propDepthsByComponent.set(componentFrame.node, new Map())
+      }
+
+      let didAddDepth = true
+      while (didAddDepth) {
+        didAddDepth = false
+        for (const propPass of propPasses) {
+          const resolvedPass = resolvePropPass(propPass, propDepthsByComponent)
+          if (!resolvedPass) continue
+          for (const sourceDepth of resolvedPass.sourceDepths) {
+            const didStoreDepth = addPropDepth(
+              propDepthsByComponent,
+              resolvedPass.targetComponentNode,
+              propPass.targetPropName,
+              sourceDepth + DEPTH_INCREMENT,
+            )
+            didAddDepth = didStoreDepth || didAddDepth
+          }
+        }
+      }
+
+      for (const propPass of propPasses) {
+        const resolvedPass = resolvePropPass(propPass, propDepthsByComponent)
+        if (!resolvedPass) continue
+        const reachesForbiddenDepth = [...resolvedPass.sourceDepths].some(
+          (sourceDepth) =>
+            sourceDepth + DEPTH_INCREMENT >= FIRST_FORBIDDEN_DEPTH,
+        )
+        if (!reachesForbiddenDepth) continue
+        context.report({
+          node: propPass.reportNode,
+          messageId: 'noPropDrilling',
+          data: {
+            name:
+              resolvedPass.sourcePropName === ALL_PROPS_NAME
+                ? 'props'
+                : resolvedPass.sourcePropName,
+          },
+        })
+      }
+    }
+
+    return {
+      FunctionDeclaration: enterComponent,
+      'FunctionDeclaration:exit': leaveComponent,
+      FunctionExpression: enterComponent,
+      'FunctionExpression:exit': leaveComponent,
+      ArrowFunctionExpression: enterComponent,
+      'ArrowFunctionExpression:exit': leaveComponent,
+      VariableDeclarator: collectPropAlias,
+      CallExpression: recordCreateElementPass,
+      JSXAttribute: recordJsxPropPass,
+      JSXSpreadAttribute: recordJsxSpreadPass,
+      'Program:exit': analyzePropPasses,
+    }
+  },
+}

--- a/lib/rules/no-prop-drilling.js
+++ b/lib/rules/no-prop-drilling.js
@@ -20,7 +20,7 @@ export default {
         'Disallow forwarding received props through two or more same-file component levels.',
       category: 'Best Practices',
       recommended: false,
-      url: 'https://github.com/laststance/react-next-eslint-plugin',
+      url: 'https://github.com/laststance/react-next-eslint-plugin/blob/main/docs/rules/no-prop-drilling.md',
     },
     fixable: null,
     hasSuggestions: false,
@@ -456,6 +456,122 @@ export default {
     }
 
     /**
+     * Checks whether one syntax node appears before the forwarding expression that depends on its value.
+     * @param {import('estree').Node} candidateNode The possible earlier write node.
+     * @param {import('estree').Node} referenceNode The forwarding expression used as the ordering boundary.
+     * @returns
+     * - True when both ranges exist and the candidate starts earlier
+     * - False when ordering cannot be proven
+     * @example
+     * isNodeBefore(assignmentIdentifier, jsxExpression) // => true
+     */
+    function isNodeBefore(candidateNode, referenceNode) {
+      const candidateStart = candidateNode.range?.[0]
+      const referenceStart = referenceNode.range?.[0]
+      return (
+        typeof candidateStart === 'number' &&
+        typeof referenceStart === 'number' &&
+        candidateStart < referenceStart
+      )
+    }
+
+    /**
+     * Detects a non-initialization write before forwarding so replaced prop bindings lose their received origin.
+     * @param {import('eslint').Scope.Variable | null} variable The prop or alias binding being inspected.
+     * @param {import('estree').Node} referenceNode The forwarding expression used as the ordering boundary.
+     * @returns
+     * - True when an assignment or update replaces the binding first
+     * - False for unchanged bindings and declaration initializers
+     * @example
+     * hasBindingWriteBefore(valueVariable, jsxExpression) // => true after value = 'local'
+     */
+    function hasBindingWriteBefore(variable, referenceNode) {
+      if (!variable) return false
+      return variable.references.some(
+        (reference) =>
+          !reference.init &&
+          reference.isWrite() &&
+          isNodeBefore(reference.identifier, referenceNode),
+      )
+    }
+
+    /**
+     * Returns the top-level props key mutated by one reference when it is an assignment, update, or delete target.
+     * @param {import('estree').Identifier} identifierNode A reference to the component props-object binding.
+     * @returns
+     * - The static top-level key, or the all-props marker for a dynamic key
+     * - null when the reference does not mutate a props member
+     * @example
+     * getMutatedPropsName(propsIdentifier) // => 'value' for props.value = 'local'
+     */
+    function getMutatedPropsName(identifierNode) {
+      const firstMemberNode = identifierNode.parent
+      if (
+        firstMemberNode?.type !== 'MemberExpression' ||
+        firstMemberNode.object !== identifierNode
+      ) {
+        return null
+      }
+
+      let mutationTargetNode = firstMemberNode
+      while (
+        mutationTargetNode.parent?.type === 'MemberExpression' &&
+        mutationTargetNode.parent.object === mutationTargetNode
+      ) {
+        mutationTargetNode = mutationTargetNode.parent
+      }
+
+      const mutationParent = mutationTargetNode.parent
+      const isMutationTarget = Boolean(
+        (mutationParent?.type === 'AssignmentExpression' &&
+          mutationParent.left === mutationTargetNode) ||
+        (mutationParent?.type === 'UpdateExpression' &&
+          mutationParent.argument === mutationTargetNode) ||
+        (mutationParent?.type === 'UnaryExpression' &&
+          mutationParent.operator === 'delete' &&
+          mutationParent.argument === mutationTargetNode),
+      )
+      if (!isMutationTarget) return null
+
+      if (!firstMemberNode.computed) {
+        return getStaticPropertyName(firstMemberNode.property) ?? ALL_PROPS_NAME
+      }
+      return firstMemberNode.property.type === 'Literal' &&
+        typeof firstMemberNode.property.value === 'string'
+        ? firstMemberNode.property.value
+        : ALL_PROPS_NAME
+    }
+
+    /**
+     * Detects an earlier props-member mutation that invalidates one static prop origin or an entire spread.
+     * @param {import('eslint').Scope.Variable | null} variable The component props-object binding.
+     * @param {string} sourcePropName The static source key or all-props marker being forwarded.
+     * @param {import('estree').Node} referenceNode The forwarding expression used as the ordering boundary.
+     * @returns
+     * - True when a relevant member was replaced before forwarding
+     * - False when earlier writes cannot affect this source prop
+     * @example
+     * hasPropsMemberWriteBefore(propsVariable, 'value', jsxExpression) // => true
+     */
+    function hasPropsMemberWriteBefore(
+      variable,
+      sourcePropName,
+      referenceNode,
+    ) {
+      if (!variable) return false
+      return variable.references.some((reference) => {
+        if (!isNodeBefore(reference.identifier, referenceNode)) return false
+        const mutatedPropName = getMutatedPropsName(reference.identifier)
+        if (!mutatedPropName) return false
+        return (
+          sourcePropName === ALL_PROPS_NAME ||
+          mutatedPropName === ALL_PROPS_NAME ||
+          mutatedPropName === sourcePropName
+        )
+      })
+    }
+
+    /**
      * Collects the first parameter's prop bindings when a component frame is created.
      * @param {{ propVariableToPropName: Map<import('eslint').Scope.Variable, string>, propsObjectVariable: import('eslint').Scope.Variable | null }} componentFrame The frame being initialized.
      * @param {import('estree').FunctionDeclaration | import('estree').FunctionExpression | import('estree').ArrowFunctionExpression} functionNode The component function.
@@ -730,47 +846,78 @@ export default {
      * Maps a direct identifier or props.member expression back to the received prop that supplied it.
      * @param {import('estree').Expression | null | undefined} expressionNode The JSX attribute expression.
      * @param {{ propVariableToPropName: Map<import('eslint').Scope.Variable, string>, propsObjectVariable: import('eslint').Scope.Variable | null }} componentFrame The component containing the expression.
+     * @param {import('estree').Node} [forwardingNode] The final forwarding expression used to ignore later writes.
      * @returns
      * - The source prop name for a direct received-prop reference
      * - null when the expression is not directly prop-derived
      * @example
      * resolveSourcePropName({ type: 'Identifier', name: 'value' }, frame) // => 'value'
      */
-    function resolveSourcePropName(expressionNode, componentFrame) {
+    function resolveSourcePropName(
+      expressionNode,
+      componentFrame,
+      forwardingNode = expressionNode,
+    ) {
       if (!expressionNode) return null
       if (expressionNode.type === 'Identifier') {
         const expressionVariable = resolveIdentifierVariable(expressionNode)
+        if (hasBindingWriteBefore(expressionVariable, forwardingNode))
+          return null
         if (expressionVariable === componentFrame.propsObjectVariable) {
+          if (
+            hasPropsMemberWriteBefore(
+              expressionVariable,
+              ALL_PROPS_NAME,
+              forwardingNode,
+            )
+          ) {
+            return null
+          }
           return ALL_PROPS_NAME
         }
         return (
           componentFrame.propVariableToPropName.get(expressionVariable) ?? null
         )
       }
-      if (
-        expressionNode.type === 'MemberExpression' &&
-        expressionNode.object.type === 'Identifier' &&
-        resolveIdentifierVariable(expressionNode.object) ===
-          componentFrame.propsObjectVariable
-      ) {
-        if (
-          !expressionNode.computed &&
-          expressionNode.property.type === 'Identifier'
-        ) {
-          return expressionNode.property.name
-        }
-        if (
-          expressionNode.computed &&
-          expressionNode.property.type === 'Literal' &&
-          typeof expressionNode.property.value === 'string'
-        ) {
-          return expressionNode.property.value
-        }
-        return null
-      }
       if (expressionNode.type === 'MemberExpression') {
+        const objectVariable =
+          expressionNode.object.type === 'Identifier'
+            ? resolveIdentifierVariable(expressionNode.object)
+            : null
+        if (objectVariable === componentFrame.propsObjectVariable) {
+          if (hasBindingWriteBefore(objectVariable, forwardingNode)) return null
+          let sourcePropName = null
+          if (
+            !expressionNode.computed &&
+            expressionNode.property.type === 'Identifier'
+          ) {
+            sourcePropName = expressionNode.property.name
+          }
+          if (
+            expressionNode.computed &&
+            expressionNode.property.type === 'Literal' &&
+            typeof expressionNode.property.value === 'string'
+          ) {
+            sourcePropName = expressionNode.property.value
+          }
+          if (
+            !sourcePropName ||
+            hasPropsMemberWriteBefore(
+              objectVariable,
+              sourcePropName,
+              forwardingNode,
+            )
+          ) {
+            return null
+          }
+          return sourcePropName
+        }
         // A nested read such as user.name remains derived from the received user prop.
-        return resolveSourcePropName(expressionNode.object, componentFrame)
+        return resolveSourcePropName(
+          expressionNode.object,
+          componentFrame,
+          forwardingNode,
+        )
       }
       return null
     }
@@ -1001,6 +1148,7 @@ export default {
         }
       }
 
+      const reportedNodes = new Set()
       for (const propPass of propPasses) {
         const resolvedPass = resolvePropPass(propPass, propDepthsByComponent)
         if (!resolvedPass) continue
@@ -1008,7 +1156,10 @@ export default {
           (sourceDepth) =>
             sourceDepth + DEPTH_INCREMENT >= FIRST_FORBIDDEN_DEPTH,
         )
-        if (!reachesForbiddenDepth) continue
+        if (!reachesForbiddenDepth || reportedNodes.has(propPass.reportNode)) {
+          continue
+        }
+        reportedNodes.add(propPass.reportNode)
         context.report({
           node: propPass.reportNode,
           messageId: 'noPropDrilling',

--- a/lib/rules/no-react-context.js
+++ b/lib/rules/no-react-context.js
@@ -1,0 +1,283 @@
+import {
+  findVariableByName,
+  getRuleScope,
+  getRuleSourceCode,
+} from '../utils/eslint-context.js'
+
+const DISALLOWED_REACT_CONTEXT_APIS = new Set(['createContext', 'useContext'])
+
+/**
+ * Reads a property name when rule visitors inspect dot or bracket access without evaluating code.
+ * @param {import('estree').MemberExpression | import('estree').Property} node - Member or object-pattern property to inspect.
+ * @returns {string | null} Static property name, or null for dynamic computed access.
+ * @example
+ * getStaticPropertyName(memberExpression) // => "useContext" for React["useContext"].
+ */
+function getStaticPropertyName(node) {
+  const property = node.type === 'Property' ? node.key : node.property
+  // Dot access exposes its name directly, while bracket access needs a string literal.
+  if (!node.computed && property.type === 'Identifier') return property.name
+  if (node.computed && property.type === 'Literal') {
+    return typeof property.value === 'string' ? property.value : null
+  }
+  return null
+}
+
+/**
+ * Recognizes the global require('react') boundary when CommonJS code is linted.
+ * @param {import('estree').Node | null | undefined} node - Potential require call.
+ * @param {import('eslint').Rule.RuleContext} context - Rule context used to reject a locally shadowed require function.
+ * @returns {boolean} True only for a global require call whose sole argument is "react".
+ * @example
+ * isReactRequireCall(callExpression, context) // => true for require('react').
+ */
+function isReactRequireCall(node, context) {
+  // Ignore calls that cannot represent the CommonJS require function.
+  if (
+    !node ||
+    node.type !== 'CallExpression' ||
+    node.callee.type !== 'Identifier' ||
+    node.callee.name !== 'require'
+  ) {
+    return false
+  }
+
+  const sourceCode = getRuleSourceCode(context)
+  const requireVariable = findVariableByName(
+    getRuleScope(context, node.callee),
+    node.callee.name,
+  )
+
+  return Boolean(
+    (sourceCode.isGlobalReference(node.callee) || !requireVariable) &&
+    node.arguments.length === 1 &&
+    node.arguments[0].type === 'Literal' &&
+    node.arguments[0].value === 'react',
+  )
+}
+
+/**
+ * Recognizes TypeScript's import-equals form when namespace checks inspect an import binding.
+ * @param {import('estree').Node} node - Import binding node that may be a TSImportEqualsDeclaration.
+ * @returns {boolean} True only for `import Name = require('react')`.
+ * @example
+ * isReactTypeScriptImportEquals(tsImportNode) // => true for import React = require('react').
+ */
+function isReactTypeScriptImportEquals(node) {
+  if (node.type !== 'TSImportEqualsDeclaration') return false
+  const moduleReference = node.moduleReference
+  return Boolean(
+    moduleReference.type === 'TSExternalModuleReference' &&
+    moduleReference.expression.type === 'Literal' &&
+    moduleReference.expression.value === 'react',
+  )
+}
+
+/**
+ * Checks variable metadata when a member visitor needs to prove a binding came from React.
+ * @param {import('eslint').Scope.Definition} definition - ESLint scope definition for a resolved variable.
+ * @param {import('eslint').Rule.RuleContext} context - Rule context used to validate CommonJS require calls.
+ * @param {Set<import('eslint').Scope.Variable>} visitedVariables - Bindings already checked while following alias chains.
+ * @returns {boolean} True for React default/namespace imports or identifiers assigned require('react').
+ * @example
+ * isReactNamespaceDefinition(definition, context, visitedVariables) // => true for import React from 'react'.
+ */
+function isReactNamespaceDefinition(definition, context, visitedVariables) {
+  // Import bindings cover standard ESM imports and TypeScript import-equals declarations.
+  if (definition.type === 'ImportBinding') {
+    if (isReactTypeScriptImportEquals(definition.node)) return true
+    return Boolean(
+      definition.parent &&
+      definition.parent.type === 'ImportDeclaration' &&
+      definition.parent.source.value === 'react' &&
+      (definition.node.type === 'ImportDefaultSpecifier' ||
+        definition.node.type === 'ImportNamespaceSpecifier'),
+    )
+  }
+
+  // Only simple variable declarations can create a namespace alias tracked by this rule.
+  if (
+    definition.type !== 'Variable' ||
+    definition.node.type !== 'VariableDeclarator' ||
+    definition.node.id.type !== 'Identifier'
+  ) {
+    return false
+  }
+
+  const initializer = definition.node.init
+  if (isReactRequireCall(initializer, context)) return true
+  return Boolean(
+    initializer &&
+    initializer.type === 'Identifier' &&
+    isReactNamespaceIdentifier(initializer, context, visitedVariables),
+  )
+}
+
+/**
+ * Verifies an identifier is the React object before member and destructuring visitors report context APIs.
+ * @param {import('estree').Identifier} identifier - Object identifier used by the candidate React API access.
+ * @param {import('eslint').Rule.RuleContext} context - Rule context that provides source and lexical scope data.
+ * @param {Set<import('eslint').Scope.Variable>} [visitedVariables] - Bindings already checked to stop cyclic aliases.
+ * @returns {boolean} True for an imported/required React object or an unshadowed global named React.
+ * @example
+ * isReactNamespaceIdentifier(identifier, context) // => true for React.useContext after importing React.
+ */
+function isReactNamespaceIdentifier(
+  identifier,
+  context,
+  visitedVariables = new Set(),
+) {
+  const sourceCode = getRuleSourceCode(context)
+  const scope = getRuleScope(context, identifier)
+  const variable = findVariableByName(scope, identifier.name)
+
+  // Unresolved identifiers only count when ESLint confirms the traditional React global.
+  if (!variable) {
+    return (
+      identifier.name === 'React' && sourceCode.isGlobalReference(identifier)
+    )
+  }
+
+  // Stop cyclic aliases before recursively following their initializer definitions.
+  if (visitedVariables.has(variable)) return false
+  visitedVariables.add(variable)
+
+  return variable.defs.some((definition) =>
+    isReactNamespaceDefinition(definition, context, visitedVariables),
+  )
+}
+
+/**
+ * Recognizes imported and required React namespace expressions before access checks report a violation.
+ * @param {import('estree').Node | null | undefined} node - Expression expected to produce the React namespace.
+ * @param {import('eslint').Rule.RuleContext} context - Rule context used for binding resolution.
+ * @returns {boolean} True when the expression is a React namespace identifier or require('react').
+ * @example
+ * isReactNamespaceExpression(identifier, context) // => true for a `ReactLibrary` namespace import.
+ */
+function isReactNamespaceExpression(node, context) {
+  // A missing initializer cannot produce the React namespace.
+  if (!node) return false
+  // Direct CommonJS access is accepted before resolving identifier aliases.
+  if (isReactRequireCall(node, context)) return true
+  return node.type === 'Identifier' && isReactNamespaceIdentifier(node, context)
+}
+
+/**
+ * Disallows React context APIs so projects use explicit data flow or an external store instead.
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow React createContext and useContext APIs.',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://github.com/laststance/react-next-eslint-plugin/blob/main/docs/rules/no-react-context.md',
+    },
+    fixable: null,
+    hasSuggestions: false,
+    schema: [],
+    messages: {
+      noReactContext:
+        'Do not use React.{{apiName}}. Prefer explicit props, component composition, or an external state store.',
+    },
+  },
+
+  /**
+   * Registers import, member, and destructuring checks when ESLint runs this rule for a source file.
+   * @param {import('eslint').Rule.RuleContext} context - ESLint rule context used to report forbidden APIs.
+   * @returns {import('eslint').Rule.RuleListener} Listeners that check every supported React API access form.
+   * @example
+   * rule.create(context) // => ESLint listeners for imports, members, and variable declarators.
+   */
+  create(context) {
+    /**
+     * Reports forbidden React context named imports as ESLint visits each import specifier.
+     * @param {import('estree').ImportSpecifier} node - Named import specifier to inspect.
+     * @returns {void} Reports once for a forbidden React context API; otherwise returns silently.
+     * @example
+     * checkImportSpecifier(importSpecifier) // Reports `import { useContext } from 'react'`.
+     */
+    function checkImportSpecifier(node) {
+      const importDeclaration = node.parent
+      // Ignore matching API names unless the named import comes from React itself.
+      if (
+        importDeclaration.type !== 'ImportDeclaration' ||
+        importDeclaration.source.value !== 'react'
+      ) {
+        return
+      }
+
+      const importedName = node.imported.name
+      // Other React named imports remain available.
+      if (!DISALLOWED_REACT_CONTEXT_APIS.has(importedName)) return
+
+      context.report({
+        node,
+        messageId: 'noReactContext',
+        data: { apiName: importedName },
+      })
+    }
+
+    /**
+     * Reports forbidden properties when a React object is accessed through dot or bracket syntax.
+     * @param {import('estree').MemberExpression} node - Member expression to inspect.
+     * @returns {void} Reports a forbidden React context API access; otherwise returns silently.
+     * @example
+     * checkMemberExpression(memberExpression) // Reports React.useContext.
+     */
+    function checkMemberExpression(node) {
+      const apiName = getStaticPropertyName(node)
+      // Dynamic or unrelated member names are outside this rule's two forbidden APIs.
+      if (!apiName || !DISALLOWED_REACT_CONTEXT_APIS.has(apiName)) return
+      // The object must resolve to React rather than a same-shaped local object.
+      if (!isReactNamespaceExpression(node.object, context)) return
+
+      context.report({
+        node,
+        messageId: 'noReactContext',
+        data: { apiName },
+      })
+    }
+
+    /**
+     * Reports forbidden properties when source code destructures APIs from a React namespace or require call.
+     * @param {import('estree').VariableDeclarator} node - Variable declaration whose object pattern may read React APIs.
+     * @returns {void} Reports each forbidden property; otherwise returns silently.
+     * @example
+     * checkVariableDeclarator(declarator) // Reports const { createContext } = require('react').
+     */
+    function checkVariableDeclarator(node) {
+      // Ignore declarations unless they destructure from a proven React namespace.
+      if (
+        node.id.type !== 'ObjectPattern' ||
+        !isReactNamespaceExpression(node.init, context)
+      ) {
+        return
+      }
+
+      // Check each destructured key because one declaration can import both forbidden APIs.
+      for (const property of node.id.properties) {
+        // Rest elements cannot name either forbidden API directly.
+        if (property.type !== 'Property') continue
+        const apiName = getStaticPropertyName(property)
+        // Preserve unrelated destructured React exports.
+        if (!apiName || !DISALLOWED_REACT_CONTEXT_APIS.has(apiName)) continue
+
+        context.report({
+          node: property,
+          messageId: 'noReactContext',
+          data: { apiName },
+        })
+      }
+    }
+
+    return {
+      ImportSpecifier: checkImportSpecifier,
+      MemberExpression: checkMemberExpression,
+      VariableDeclarator: checkVariableDeclarator,
+    }
+  },
+}

--- a/lib/rules/no-react-context.js
+++ b/lib/rules/no-react-context.js
@@ -4,6 +4,7 @@ import {
   getRuleSourceCode,
 } from '../utils/eslint-context.js'
 
+const REACT_MODULE_NAME = 'react'
 const DISALLOWED_REACT_CONTEXT_APIS = new Set(['createContext', 'useContext'])
 
 /**
@@ -52,7 +53,7 @@ function isReactRequireCall(node, context) {
     (sourceCode.isGlobalReference(node.callee) || !requireVariable) &&
     node.arguments.length === 1 &&
     node.arguments[0].type === 'Literal' &&
-    node.arguments[0].value === 'react',
+    node.arguments[0].value === REACT_MODULE_NAME,
   )
 }
 
@@ -69,7 +70,7 @@ function isReactTypeScriptImportEquals(node) {
   return Boolean(
     moduleReference.type === 'TSExternalModuleReference' &&
     moduleReference.expression.type === 'Literal' &&
-    moduleReference.expression.value === 'react',
+    moduleReference.expression.value === REACT_MODULE_NAME,
   )
 }
 
@@ -89,7 +90,7 @@ function isReactNamespaceDefinition(definition, context, visitedVariables) {
     return Boolean(
       definition.parent &&
       definition.parent.type === 'ImportDeclaration' &&
-      definition.parent.source.value === 'react' &&
+      definition.parent.source.value === REACT_MODULE_NAME &&
       (definition.node.type === 'ImportDefaultSpecifier' ||
         definition.node.type === 'ImportNamespaceSpecifier'),
     )
@@ -205,7 +206,7 @@ export default {
       // Ignore matching API names unless the named import comes from React itself.
       if (
         importDeclaration.type !== 'ImportDeclaration' ||
-        importDeclaration.source.value !== 'react'
+        importDeclaration.source.value !== REACT_MODULE_NAME
       ) {
         return
       }

--- a/lib/utils/eslint-context.js
+++ b/lib/utils/eslint-context.js
@@ -52,3 +52,22 @@ export function getRuleScope(context, node) {
   }
   return null
 }
+
+/**
+ * Resolves the nearest lexical binding when rule helpers must distinguish imported values from shadowed names.
+ * @param {import('eslint').Scope.Scope | null} scope - Starting lexical scope for an identifier.
+ * @param {string} variableName - Identifier name to resolve.
+ * @returns {import('eslint').Scope.Variable | null} Nearest variable binding, or null for an unresolved global.
+ * @example
+ * findVariableByName(scope, 'React') // => the imported React variable when it is in scope.
+ */
+export function findVariableByName(scope, variableName) {
+  let currentScope = scope
+  // Walk outward so a local parameter wins over a same-named outer import.
+  while (currentScope) {
+    const variable = currentScope.set.get(variableName)
+    if (variable) return variable
+    currentScope = currentScope.upper
+  }
+  return null
+}

--- a/lib/utils/jsx-attributes.js
+++ b/lib/utils/jsx-attributes.js
@@ -2,7 +2,7 @@
  * JSX attribute helpers that resolve direct and spread props.
  */
 
-import { getRuleScope } from './eslint-context.js'
+import { findVariableByName, getRuleScope } from './eslint-context.js'
 
 const PROPERTY_NODE_TYPES = new Set(['Property'])
 const FIRST_DEFINITION_INDEX = 0
@@ -15,23 +15,6 @@ const FIRST_DEFINITION_INDEX = 0
  */
 function getScope(context, node) {
   return getRuleScope(context, node)
-}
-
-/**
- * Finds a variable by name in the given scope chain.
- * @param {import('eslint').Scope.Scope} scope - Starting scope.
- * @param {string} name - Variable name to look up.
- * @returns {import('eslint').Scope.Variable | null} The matching variable or null.
- */
-function findVariable(scope, name) {
-  let current = scope
-  while (current) {
-    if (current.set && current.set.has(name)) {
-      return current.set.get(name)
-    }
-    current = current.upper
-  }
-  return null
 }
 
 /**
@@ -66,7 +49,10 @@ function isPropertyName(property, name) {
   if (property.key.type === 'Identifier') {
     return property.key.name === name
   }
-  if (property.key.type === 'Literal' && typeof property.key.value === 'string') {
+  if (
+    property.key.type === 'Literal' &&
+    typeof property.key.value === 'string'
+  ) {
     return property.key.value === name
   }
   return false
@@ -93,7 +79,7 @@ function findPropertyInObject(name, properties, scope, seen) {
     if (argument.type === 'Identifier') {
       if (seen.has(argument.name)) continue
       seen.add(argument.name)
-      const variable = findVariable(scope, argument.name)
+      const variable = findVariableByName(scope, argument.name)
       const variableNode = getVariableDefinitionNode(variable)
       if (variableNode && variableNode.type === 'ObjectExpression') {
         const found = findPropertyInObject(
@@ -140,7 +126,7 @@ export function getJsxAttribute(context, node, initialScope) {
         )
       }
       if (argument.type === 'Identifier') {
-        const variable = findVariable(scope, argument.name)
+        const variable = findVariableByName(scope, argument.name)
         const variableNode = getVariableDefinitionNode(variable)
         if (variableNode && variableNode.type === 'ObjectExpression') {
           return Boolean(

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@laststance/npm-publish-tool": "^2.0.0",
+    "@typescript-eslint/parser": "^8.57.0",
     "eslint": "^10.1.0",
     "mocha": "^11.7.5",
     "npm-run-all2": "^8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@laststance/npm-publish-tool':
         specifier: ^2.0.0
         version: 2.0.0(@types/node@20.19.25)
+      '@typescript-eslint/parser':
+        specifier: ^8.57.0
+        version: 8.57.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^10.1.0
         version: 10.1.0(jiti@2.6.1)
@@ -1276,6 +1279,7 @@ packages:
   basic-ftp@5.2.0:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -3440,6 +3444,18 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.57.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.1.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/tests/lib/rules/no-prop-drilling.test.js
+++ b/tests/lib/rules/no-prop-drilling.test.js
@@ -1,0 +1,390 @@
+import { RuleTester } from 'eslint'
+import rule from '../../../lib/rules/no-prop-drilling.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2024,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run('no-prop-drilling', rule, {
+  valid: [
+    {
+      name: 'allows rendering a received prop after one same-file component boundary',
+      // Arrange: a received prop crosses one component boundary and is rendered by the child.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester runs the rule with its fixed one-level allowance.
+      // Assert: rendering after one component boundary produces no error.
+    },
+    {
+      name: 'allows consuming a received prop in an intrinsic element',
+      // Arrange: the child consumes the received prop in an intrinsic element attribute.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <div data-value={value} />;
+        }
+      `,
+      // Act: RuleTester sees the intrinsic JSX target without adding a component edge.
+      // Assert: DOM consumption is naturally outside the component-depth graph.
+    },
+    {
+      name: 'allows an imported component to end the known same-file chain',
+      // Arrange: a received prop leaves the known graph through an imported component.
+      code: `
+        import { LibraryWidget } from 'library';
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <LibraryWidget value={value} />;
+        }
+      `,
+      // Act: RuleTester cannot connect the imported target to a same-file definition.
+      // Assert: no library allowlist is required and the unknown edge is not reported.
+    },
+    {
+      name: 'allows a local value to cross two components before it becomes a drilled prop',
+      // Arrange: a locally created value, rather than a received prop, crosses two components.
+      code: `
+        function Parent() {
+          const value = 'local';
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester looks for a received-prop source at the first component edge.
+      // Assert: local values are outside this rule's prop-drilling contract.
+    },
+    {
+      name: 'allows an imported target when an unrelated nested component has the same name',
+      // Arrange: an import and a nested same-file component share one PascalCase name.
+      code: `
+        import { Child } from './child.js';
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function UnrelatedWrapper() {
+          function Child({ value }) {
+            return <Grandchild value={value} />;
+          }
+          return <Child value="local" />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester resolves each Child reference from its lexical scope.
+      // Assert: the imported edge does not connect to the unrelated nested definition.
+    },
+    {
+      name: 'allows a callback-local value that shadows a received prop',
+      // Arrange: a nested callback shadows the prop name before rendering another component.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          const renderLocalValue = () => {
+            const value = 'local';
+            return <Grandchild value={value} />;
+          };
+          return <section>{renderLocalValue()}</section>;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester resolves the JSX identifier to the callback-local binding.
+      // Assert: a shadowed local value is not treated as the outer received prop.
+    },
+    {
+      name: 'allows local createElement and memo helpers that do not come from React',
+      // Arrange: local helpers share React API names but have no React binding.
+      code: `
+        function createElement(target, props) {
+          return { target, props };
+        }
+        function memo(component) {
+          return component;
+        }
+        function Parent({ value }) {
+          return createElement(Child, { value });
+        }
+        const Child = memo(({ value }) => createElement(Grandchild, { value }));
+        function Grandchild({ value }) {
+          return createElement('span', { value });
+        }
+      `,
+      // Act: RuleTester resolves both helper callees from lexical imports.
+      // Assert: matching local names are not treated as React component syntax.
+    },
+  ],
+  invalid: [
+    {
+      name: 'reports the second same-file component boundary for a received prop',
+      // Arrange: a received prop is forwarded through two component boundaries.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester runs the rule with its fixed one-level allowance.
+      // Assert: only the second component boundary is rejected.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports every same-file forwarding boundary from depth two onward',
+      // Arrange: the same received prop is forwarded across three component boundaries.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <GreatGrandchild value={value} />;
+        }
+        function GreatGrandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester evaluates every same-file component edge.
+      // Assert: both the second and third forwarding levels are rejected.
+      errors: [
+        { messageId: 'noPropDrilling' },
+        { messageId: 'noPropDrilling' },
+      ],
+    },
+    {
+      name: 'reports the second boundary after a received prop is aliased',
+      // Arrange: the child renames a received prop before forwarding it again.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          const forwardedValue = value;
+          return <Grandchild value={forwardedValue} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester evaluates the alias used by the second component edge.
+      // Assert: renaming the value does not bypass the depth restriction.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary when props objects and receiving names differ',
+      // Arrange: props objects and different receiving prop names form the same two-level chain.
+      code: `
+        function Parent(props) {
+          return <Child currentValue={props.value} />;
+        }
+        function Child(props) {
+          return <Grandchild displayValue={props.currentValue} />;
+        }
+        function Grandchild({ displayValue }) {
+          return <span>{displayValue}</span>;
+        }
+      `,
+      // Act: RuleTester follows each static props.member reference by its receiving name.
+      // Assert: changing prop names does not reset the component depth.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary when complete props objects are spread',
+      // Arrange: the complete props object is spread across two component boundaries.
+      code: `
+        function Parent(props) {
+          return <Child {...props} />;
+        }
+        function Child(props) {
+          return <Grandchild {...props} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester evaluates both JSX spread edges.
+      // Assert: spreading props does not bypass the second-level restriction.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary when components use React.createElement',
+      // Arrange: received props are forwarded twice with React.createElement.
+      code: `
+        import React from 'react';
+        function Parent({ value }) {
+          return React.createElement(Child, { value });
+        }
+        function Child({ value }) {
+          return React.createElement(Grandchild, { value });
+        }
+        function Grandchild({ value }) {
+          return React.createElement('span', null, value);
+        }
+      `,
+      // Act: RuleTester evaluates createElement component and props arguments.
+      // Assert: JSX-free component syntax follows the same second-level restriction.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary for a property read from an object prop',
+      // Arrange: the second component forwards a property read from a received object prop.
+      code: `
+        function Parent({ user }) {
+          return <Child user={user} />;
+        }
+        function Child({ user }) {
+          return <Grandchild label={user.name} />;
+        }
+        function Grandchild({ label }) {
+          return <span>{label}</span>;
+        }
+      `,
+      // Act: RuleTester traces the member expression back to its received object prop.
+      // Assert: reading a nested value does not reset the forwarding depth.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary inside an anonymous memoized component',
+      // Arrange: the forwarding component is an anonymous arrow wrapped in React.memo.
+      code: `
+        import { memo } from 'react';
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        const Child = memo(({ value }) => <Grandchild value={value} />);
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester resolves the memoized variable as the Child component.
+      // Assert: memoization does not hide the second component boundary.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary from a conditional component return',
+      // Arrange: the forwarding component returns JSX from an if branch.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          if (value) {
+            return <Grandchild value={value} />;
+          }
+          return null;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester inspects returns nested in the component's control flow.
+      // Assert: conditional rendering does not hide the second boundary.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary from a conditional arrow expression',
+      // Arrange: an arrow component returns JSX through a conditional expression.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        const Child = ({ value }) =>
+          value ? <Grandchild value={value} /> : null;
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester searches the arrow expression for JSX branches.
+      // Assert: expression-style conditional rendering still exposes depth two.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary after props are destructured in the component body',
+      // Arrange: the child destructures its props object before forwarding one value.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child(props) {
+          const { value } = props;
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester follows the body-level destructured binding.
+      // Assert: moving destructuring out of the parameter does not bypass depth two.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary after rest props are created in the component body',
+      // Arrange: both components spread props and the child first creates a rest alias.
+      code: `
+        function Parent(props) {
+          return <Child {...props} />;
+        }
+        function Child(props) {
+          const { ...restProps } = props;
+          return <Grandchild {...restProps} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester follows the rest binding as the same received props object.
+      // Assert: body-level rest spreading cannot reset the known depth.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports the second boundary after rest props are created in the component parameter',
+      // Arrange: the child receives all remaining props through parameter-level rest syntax.
+      code: `
+        function Parent(props) {
+          return <Child {...props} />;
+        }
+        function Child({ ...restProps }) {
+          return <Grandchild {...restProps} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester follows the parameter rest binding as the received props object.
+      // Assert: parameter-level rest syntax cannot reset the known depth.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+  ],
+})

--- a/tests/lib/rules/no-prop-drilling.test.js
+++ b/tests/lib/rules/no-prop-drilling.test.js
@@ -139,6 +139,61 @@ ruleTester.run('no-prop-drilling', rule, {
       // Act: RuleTester resolves both helper callees from lexical imports.
       // Assert: matching local names are not treated as React component syntax.
     },
+    {
+      name: 'allows a reassigned destructured prop to cross the second component boundary',
+      // Arrange: the child replaces its received binding with a local value before forwarding it.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          value = 'local';
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester resolves the write that occurs before the child forwarding expression.
+      // Assert: the replacement value is no longer classified as a received prop.
+    },
+    {
+      name: 'allows a reassigned prop alias to cross the second component boundary',
+      // Arrange: the child aliases a received prop, then replaces the alias before forwarding it.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          let forwardedValue = value;
+          forwardedValue = 'local';
+          return <Grandchild value={forwardedValue} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester follows both the alias initializer and its later write.
+      // Assert: a replaced alias does not retain its received-prop origin.
+    },
+    {
+      name: 'allows a reassigned props member to cross the second component boundary',
+      // Arrange: the child replaces one props-object member before forwarding that member.
+      code: `
+        function Parent(props) {
+          return <Child value={props.value} />;
+        }
+        function Child(props) {
+          props.value = 'local';
+          return <Grandchild value={props.value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester inspects member writes that occur before the forwarded read.
+      // Assert: the mutated member is not treated as the value received from Parent.
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/no-prop-drilling.test.js
+++ b/tests/lib/rules/no-prop-drilling.test.js
@@ -481,5 +481,47 @@ ruleTester.run('no-prop-drilling', rule, {
       // Assert: only the earlier received-prop forwarding edge remains a violation.
       errors: [{ messageId: 'noPropDrilling' }],
     },
+    {
+      name: 'reports forwarding when only an uninvoked callback reassigns the prop binding',
+      // Arrange: a nested callback contains a binding write but is never called before forwarding.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          const resetValue = () => {
+            value = 'local';
+          };
+          return <Grandchild value={value} resetValue={resetValue} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester compares the nested write owner with the forwarding component body.
+      // Assert: the unexecuted callback cannot erase the received-prop violation.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports forwarding when only an uninvoked callback mutates a destructured object prop',
+      // Arrange: a nested callback mutates user.name but is never called before forwarding.
+      code: `
+        function Parent({ user }) {
+          return <Child user={user} />;
+        }
+        function Child({ user }) {
+          const resetUser = () => {
+            user.name = 'local';
+          };
+          return <Grandchild value={user.name} resetUser={resetUser} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester compares the member-write owner with the forwarding component body.
+      // Assert: an unexecuted nested mutation cannot make user.name local.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
   ],
 })

--- a/tests/lib/rules/no-prop-drilling.test.js
+++ b/tests/lib/rules/no-prop-drilling.test.js
@@ -194,6 +194,24 @@ ruleTester.run('no-prop-drilling', rule, {
       // Act: RuleTester inspects member writes that occur before the forwarded read.
       // Assert: the mutated member is not treated as the value received from Parent.
     },
+    {
+      name: 'allows a reassigned member of a destructured object prop to cross the second component boundary',
+      // Arrange: the child replaces a member of its destructured object prop before forwarding it.
+      code: `
+        function Parent({ user }) {
+          return <Child user={user} />;
+        }
+        function Child({ user }) {
+          user.name = 'local';
+          return <Grandchild value={user.name} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester follows the member write through the destructured user binding.
+      // Assert: the replaced member no longer carries the received user prop origin.
+    },
   ],
   invalid: [
     {
@@ -439,6 +457,28 @@ ruleTester.run('no-prop-drilling', rule, {
       `,
       // Act: RuleTester follows the parameter rest binding as the received props object.
       // Assert: parameter-level rest syntax cannot reset the known depth.
+      errors: [{ messageId: 'noPropDrilling' }],
+    },
+    {
+      name: 'reports forwarding that occurs before a later reassignment of the same prop binding',
+      // Arrange: one branch forwards the received prop before a later branch replaces and forwards it.
+      code: `
+        function Parent({ value }) {
+          return <Child value={value} />;
+        }
+        function Child({ value }) {
+          if (value) {
+            return <Grandchild value={value} />;
+          }
+          value = 'local';
+          return <Grandchild value={value} />;
+        }
+        function Grandchild({ value }) {
+          return <span>{value}</span>;
+        }
+      `,
+      // Act: RuleTester compares each forwarding expression with the later write position.
+      // Assert: only the earlier received-prop forwarding edge remains a violation.
       errors: [{ messageId: 'noPropDrilling' }],
     },
   ],

--- a/tests/lib/rules/no-react-context.test.js
+++ b/tests/lib/rules/no-react-context.test.js
@@ -1,0 +1,267 @@
+import { RuleTester } from 'eslint'
+import rule from '../../../lib/rules/no-react-context.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2024,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-react-context', rule, {
+  valid: [
+    {
+      name: 'allows local functions that share React context API names',
+      // Arrange & Act
+      code: `
+        function createContext() {
+          return 'local factory'
+        }
+
+        function useContext() {
+          return 'local reader'
+        }
+
+        createContext()
+        useContext()
+      `,
+      // Assert: RuleTester expects no diagnostics.
+    },
+    {
+      name: 'allows matching named imports from non-React modules',
+      // Arrange & Act
+      code: `
+        import { createContext, useContext } from './custom-context.js'
+
+        createContext()
+        useContext()
+      `,
+      // Assert: RuleTester expects no diagnostics.
+    },
+    {
+      name: 'allows unrelated object methods and shadowed React parameters',
+      // Arrange & Act
+      code: `
+        import React from 'react'
+
+        const contextFactory = {
+          createContext() {},
+          useContext() {},
+        }
+
+        function readLocalContext(React) {
+          contextFactory.createContext()
+          contextFactory.useContext()
+          return React.useContext()
+        }
+
+        readLocalContext(contextFactory)
+      `,
+      // Assert: RuleTester expects no diagnostics.
+    },
+    {
+      name: 'allows a locally shadowed require function that returns context-like APIs',
+      // Arrange & Act
+      code: `
+        function require() {
+          return {
+            createContext() {},
+            useContext() {},
+          }
+        }
+
+        const ReactLibrary = require('react')
+        ReactLibrary.createContext()
+        ReactLibrary.useContext()
+      `,
+      // Assert: RuleTester expects no diagnostics.
+    },
+    {
+      name: 'allows cyclic local aliases that do not originate from React',
+      // Arrange & Act
+      code: `
+        const FirstAlias = SecondAlias
+        const SecondAlias = FirstAlias
+
+        FirstAlias.useContext()
+      `,
+      // Assert: RuleTester expects no diagnostics.
+    },
+  ],
+  invalid: [
+    {
+      name: 'rejects React createContext and useContext named imports',
+      // Arrange & Act
+      code: `
+        import { createContext, useContext } from 'react'
+
+        const ThemeContext = createContext('light')
+        const theme = useContext(ThemeContext)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects aliased React context named imports',
+      // Arrange & Act
+      code: `
+        import {
+          createContext as makeContext,
+          useContext as readContext,
+        } from 'react'
+
+        makeContext(null)
+        readContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs accessed through React import objects',
+      // Arrange & Act
+      code: `
+        import React, * as ReactNamespace from 'react'
+
+        React.createContext(null)
+        ReactNamespace.useContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects computed context API access through a React import alias',
+      // Arrange & Act
+      code: `
+        import ReactLibrary from 'react'
+
+        ReactLibrary['useContext'](null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs destructured from a React CommonJS require',
+      // Arrange & Act
+      code: `
+        const {
+          createContext: makeContext,
+          useContext: readContext,
+        } = require('react')
+
+        makeContext(null)
+        readContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs accessed through React CommonJS objects',
+      // Arrange & Act
+      code: `
+        const ReactLibrary = require('react')
+
+        ReactLibrary.createContext(null)
+        require('react').useContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs destructured from a React namespace import',
+      // Arrange & Act
+      code: `
+        import * as ReactLibrary from 'react'
+
+        const { createContext, useContext: readContext } = ReactLibrary
+
+        createContext(null)
+        readContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs accessed through chained React aliases',
+      // Arrange & Act
+      code: `
+        import React from 'react'
+
+        const ReactAlias = React
+        const NestedReactAlias = ReactAlias
+
+        ReactAlias.createContext(null)
+        NestedReactAlias.useContext(null)
+      `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+  ],
+})

--- a/tests/lib/rules/no-react-context.test.js
+++ b/tests/lib/rules/no-react-context.test.js
@@ -1,3 +1,4 @@
+import tsParser from '@typescript-eslint/parser'
 import { RuleTester } from 'eslint'
 import rule from '../../../lib/rules/no-react-context.js'
 
@@ -5,6 +6,9 @@ const ruleTester = new RuleTester({
   languageOptions: {
     ecmaVersion: 2024,
     sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
   },
 })
 
@@ -251,6 +255,30 @@ ruleTester.run('no-react-context', rule, {
         ReactAlias.createContext(null)
         NestedReactAlias.useContext(null)
       `,
+      // Assert
+      errors: [
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'createContext' },
+        },
+        {
+          messageId: 'noReactContext',
+          data: { apiName: 'useContext' },
+        },
+      ],
+    },
+    {
+      name: 'rejects context APIs accessed through a TypeScript import-equals binding',
+      // Arrange & Act
+      code: `
+        import React = require('react')
+
+        React.createContext(null)
+        React.useContext(null)
+      `,
+      languageOptions: {
+        parser: tsParser,
+      },
       // Assert
       errors: [
         {


### PR DESCRIPTION
## Summary

- add no-react-context to prohibit React createContext and useContext APIs
- add no-prop-drilling to allow one component boundary and report forwarding at depth 2 or deeper
- track destructuring, aliases, rest/spread props, conditional returns, memo, and createElement within same-file component graphs
- expose both rules through the public API, types, recommended config, documentation, and demo snapshots

## Validation

- pnpm test (269 passing)
- pnpm lint
- pnpm typecheck
- pnpm --filter todo-lint-app test (11 passing, 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `no-react-context` to warn on `createContext`/`useContext` usage patterns.
  * Added `no-prop-drilling` to warn on forwarded props across multiple same-file component levels.
  * Enabled both rules (as warnings) in the main and v10-compat configurations, with new demo app examples and fixtures.

* **Documentation**
  * Added complete rule documentation (descriptions, incorrect/correct examples, and behavioral notes) and updated the README/rules index.

* **Tests**
  * Added rule test suites, expanded focused v10 assertions, and added new valid/invalid lint fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->